### PR TITLE
Add parity to kube resources on envproxy

### DIFF
--- a/templates/_envproxy.tpl
+++ b/templates/_envproxy.tpl
@@ -25,6 +25,7 @@ rules:
       - secrets
       - deployments
       - configmaps
+      - persistentvolumeclaims
     verbs:
       - create
       - list
@@ -50,6 +51,17 @@ rules:
     verbs:
       - list
       - get
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+    # Necessary for preventing inter-environment communication.
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
 {{- end }}
 {{- end }}
 {{/*


### PR DESCRIPTION
Now that the kprovider is used on envproxy it needs the same kube permissions for getting resources as cemanager