### PR TITLE
Add cemanager url and creds env vars for envproxy detachment

### DIFF
--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -98,3 +98,12 @@ tolerations:
 {{ toYaml .Values.serviceTolerations }}
 {{- end }}
 {{- end }}
+{{/*
+  coder.envproxyCredsEnv - temporary POC for intra-service auth
+*/}}
+{{- define "coder.envproxyCredsEnv" }}
+- name: "CODER_SERVER_USER"
+  value: {{ now | date "2006-01-02" | sha256sum }}
+- name: "CODER_SERVER_KEY"
+  value: {{ now | date "2006-01-02" | sha256sum }}
+{{- end }}

--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -90,6 +90,7 @@ spec:
 {{- include "coder.namespaceWhitelist.env" . | indent 12 }}
 {{- include "coder.devurls.hostEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}
+{{- include "coder.envproxyCredsEnv" . | indent 12 }}
           command:
             # Bash is needed to pass signals correctly.
             - /bin/bash

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -69,6 +69,9 @@ spec:
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.devurls.hostEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}
+{{- include "coder.envproxyCredsEnv" . | indent 12 }}
+            - name: CEMANAGER_ACCESS_URL
+              value: "http://cemanager:8080"
           command:
             # Bash needs to be used for signals to be passed down correctly.
             - /bin/bash

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -71,7 +71,7 @@ spec:
 {{- include "coder.postgres.env" . | indent 12 }}
 {{- include "coder.envproxyCredsEnv" . | indent 12 }}
             - name: CEMANAGER_ACCESS_URL
-              value: "http://cemanager:8080"
+              value: "http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix}}:8080"
           command:
             # Bash needs to be used for signals to be passed down correctly.
             - /bin/bash


### PR DESCRIPTION
This enables communication between envproxy and cemanager, which will soon be the only way for envproxy to handle authenticating requests. Right now we generate a shared user and key secret between both services, this will probably change in the future but works for now. 