### PR TITLE
Add field for supplying custom annotations to default ingress service…

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -293,6 +293,10 @@ metadata:
   labels:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
+  annotations:
+  {{- range $key, $value := .Values.ingress.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer

--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,8 @@ ingress:
   # escalation, and access to privileged ports to successfully deploy.
   podSecurityPolicyName: ""
   # ingress.additionalAnnotations -- Additional annotations to be used when
-  # creating the ingress. These can be used to specify certificate issuers or
+  # creating the ingress. These only apply to the Ingress Kubernetes kind.
+  # The annotations can be used to specify certificate issuers or
   # other cloud provider specific integrations. Annotations are provided as
   # strings e.g. [ "mykey:myvalue", "mykey2:myvalue2" ] 
   additionalAnnotations: []
@@ -54,6 +55,13 @@ ingress:
     # ingress.tls.devurlsHostSecretName -- The secret to use for the
     # devurls.host hostname.
     devurlsHostSecretName: ""
+  # ingress.service -- Options related to the ingress Kubernetes Service object.
+  service:
+    # ingress.service.annotations -- Additional annotations to add to the Service
+    # object. For example to make the ingress spawn an internal load balancer:
+    # annotations:
+    #  cloud.google.com/load-balancer-type: "Internal" 
+    annotations: {}
 
 devurls:
   # devurls.host -- Should be a wildcard hostname to allow matching against


### PR DESCRIPTION
[ch3913]

```bash
coder@cvm helm (service-annotations) kubectl describe service ingress-nginx
Name:                     ingress-nginx
Namespace:                sreya
Labels:                   app.kubernetes.io/managed-by=Helm
                          app.kubernetes.io/name=ingress-nginx
                          app.kubernetes.io/part-of=ingress-nginx
Annotations:              cloud.google.com/load-balancer-type: Internal
                          meta.helm.sh/release-name: coder
                          meta.helm.sh/release-namespace: sreya
Selector:                 app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/part-of=ingress-nginx
```

```bash
coder@cvm helm (service-annotations) kubectl get services 
NAME            TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)                                   AGE
ingress-nginx   LoadBalancer   [redacted]    10.1.0.3      80:31898/TCP,443:32727/TCP,22:30310/TCP   21m
```