### PR TITLE
inject pod tolerations as JSON string for new POD_TOLERATIONS env var

### DIFF
--- a/templates/_environments.tpl
+++ b/templates/_environments.tpl
@@ -27,12 +27,12 @@ data:
 {{- end}}
 {{- end}}
 {{/*
-  coder.environments.configMapEnv adds an environment variable with the name 
-  of the config map holding additional user environment configuration.
+  coder.environments.configMapEnv contains a POD_TOLERATIONS environment variable.
+  ce-manager uses this environment variable to unmarshal pod toleration objects.
 */}}
 {{- define "coder.environments.configMapEnv" }}
-{{- if .Values.serviceTolerations }}
-- name: ENVIRONMENT_CONFIG_MAP
-  value: "ce-environment-config"
+{{- if .Values.environments.tolerations }}
+- name: POD_TOLERATIONS
+  value: {{ toJson .Values.environments.tolerations | b64enc | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What this does?

### Old process

1. Helm chart stores pod tolerations in `tolerations` key inside the environments config map.

2. Opening `kprovider` client requires the kube api-server to get the config map.

That's because the config map name is required to parse out the pod tolerations.

### New process

1. Helm chart stores pod tolerations JSON in `POD_TOLERATIONS` environment variable.

2. If `POD_TOLERATIONS` env var is set, ce-manager parses them out of the environment into new `v1.PodToleration` kube objects.

### Benefits

1. Removes reliance on kube apiserver
2. Removes reliance on config map
3. Cleaner code
4. Faster performance

### Notes

This PR should be reviewed in conjunction with cdr/c [6206](https://github.com/cdr/c/pull/6206)