### PR TITLE
add storage class permissions

### DIFF
--- a/templates/_cemanager.tpl
+++ b/templates/_cemanager.tpl
@@ -80,7 +80,7 @@ rules:
       - list
       - patch
   - apiGroups:
-      - storage.k8s.io/v1
+      - storage.k8s.io
     resources:
       - storageclasses
     verbs:

--- a/templates/_cemanager.tpl
+++ b/templates/_cemanager.tpl
@@ -79,6 +79,14 @@ rules:
       - get
       - list
       - patch
+  - apiGroups:
+      - storage.k8s.io/v1
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 {{- end }}
 {{/*

--- a/templates/_envproxy.tpl
+++ b/templates/_envproxy.tpl
@@ -62,6 +62,14 @@ rules:
       - get
       - list
       - patch
+  - apiGroups:
+      - storage.k8s.io/v1
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}
 {{- end }}
 {{/*

--- a/templates/_envproxy.tpl
+++ b/templates/_envproxy.tpl
@@ -63,7 +63,7 @@ rules:
       - list
       - patch
   - apiGroups:
-      - storage.k8s.io/v1
+      - storage.k8s.io
     resources:
       - storageclasses
     verbs:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -112,6 +112,15 @@ rules:
       - ingresses/status
     verbs:
       - update
+  - apiGroups:
+      - "extensions"
+      - "storage.k8s.io"
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role


### PR DESCRIPTION
# What this does?

Enables the `kprovider` to manage storage class resources  as part of a greater effort to prevent environment volume resizes when the storage class for said environment does not allow volume expansion. See [6351](https://github.com/cdr/m/pull/6351).