### PR TITLE
fix: change readiness/liveness probes to reasonable intervals

### DIFF
--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -136,26 +136,18 @@ spec:
                 - curl
                 - -s
                 - localhost:8080/cem-healthz
-            initialDelaySeconds: 30
-            failureThreshold: 12
-            # Poll the manager every 20 seconds. If we fail 12 times (4
-            # minutes) the manager is most likely in a bad spot. It's possible
-            # for migrations to take extended periods of time, so we need to
-            # account for that.
-            periodSeconds: 20
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
           livenessProbe:
             exec:
               command:
                 - curl
                 - -s
                 - localhost:8080/cem-healthz
-            initialDelaySeconds: 30
-            failureThreshold: 12
-            # Poll the manager every 20 seconds. If we fail 12 times (4
-            # minutes) the manager is most likely in a bad spot. It's possible
-            # for migrations to take extended periods of time, so we need to
-            # account for that.
-            periodSeconds: 20
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
 {{- include "coder.resources" .Values.cemanager.resources | indent 10 }}
 {{- include "coder.volumeMounts" . | indent 10 }}
 {{- include "coder.volumes" . | indent 6 }}

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -45,18 +45,18 @@ spec:
                 - curl
                 - -s
                 - localhost:3000/healthz
-            initialDelaySeconds: 8
-            failureThreshold: 12
-            periodSeconds: 4
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
           livenessProbe:
             exec:
               command:
                 - curl
                 - -s
                 - localhost:3000/healthz
-            initialDelaySeconds: 30
-            failureThreshold: 14
-            periodSeconds: 20
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
 {{- include "coder.resources" .Values.dashboard.resources | indent 10 }}
 ---
 apiVersion: v1

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -102,27 +102,19 @@ spec:
               command:
                 - curl
                 - -s
-                - localhost:8080/healthz
-            initialDelaySeconds: 30
-            failureThreshold: 12
-            # Poll envproxy every 20 seconds. If we fail 12 times (4 minutes)
-            # the manager is most likely in a bad spot. It's possible for
-            # migrations to take extended periods of time, so we need to
-            # account for that.
-            periodSeconds: 20
+                - localhost:8080/healthzz
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
           livenessProbe:
             exec:
               command:
                 - curl
                 - -s
                 - localhost:8080/healthz
-            initialDelaySeconds: 30
-            failureThreshold: 14
-            # Poll envproxy every 20 seconds. If we fail 12 times (4 minutes)
-            # the manager is most likely in a bad spot. It's possible for
-            # migrations to take extended periods of time, so we need to
-            # account for that.
-            periodSeconds: 20
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
 {{- include "coder.resources" .Values.envproxy.resources | indent 10 }}
 {{- include "coder.volumeMounts" . | indent 10 }}
 {{- include "coder.volumes" . | indent 6 }}


### PR DESCRIPTION
Now that we don't have to account for migrations while the probes are
running, we're free to set these back to reasonable times so it doesn't
take ages for cemanager/envproxy to be detected as ready.