### PR TITLE
Rename 'local' envproxy to 'built-in'

### DIFF
--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -115,10 +115,10 @@ spec:
                   fieldPath: metadata.namespace
             - name: VERBOSE
               value: "true"
-            - name: LOCAL_ENVPROXY_TOKEN
+            - name: BUILT_IN_ENVPROXY_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: local-envproxy-token
+                  name: built-in-envproxy-token
                   key: token
               # ENVIRONMENT_SERVICE_ACCOUNT is the service account to assign
               # to all user environments. It's primarily used to ensure

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: local-envproxy-token
+  name: built-in-envproxy-token
   namespace: {{ .Release.Namespace | quote }}
 type: Opaque
 # Adapted from https://stackoverflow.com/a/64325744
 data:
-  {{- if (lookup "v1" "Secret" .Release.Namespace "local-envproxy-token") }}
-  token: {{ (lookup "v1" "Secret" .Release.Namespace "local-envproxy-token").data.token }}
+  {{- if (lookup "v1" "Secret" .Release.Namespace "built-in-envproxy-token") }}
+  token: {{ (lookup "v1" "Secret" .Release.Namespace "built-in-envproxy-token").data.token }}
   {{- else }}
   token: {{ randAlphaNum 32 | b64enc }}
   {{- end }}
@@ -100,7 +100,7 @@ spec:
             - name: CEMANAGER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: local-envproxy-token
+                  name: built-in-envproxy-token
                   key: token
             - name: STORAGE_CLASS
               value: {{ .Values.storageClassName | quote }}


### PR DESCRIPTION
This will recreate the token secret, but it should be fine since we auto-migrate on startup of cemanager, and the old one will be cleaned up from helm. woohoo