### PR TITLE
chore: use dependabot to track GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "11:00"
+  ignore:
+    # GitHub always delivers the latest versions for each major
+    # release tag, so ignore minor version tags
+    - dependency-name: "actions/cache"
+      versions:
+        - 2.x
+    - dependency-name: "actions/checkout"
+      versions:
+        - 2.x


### PR DESCRIPTION
This configures dependabot to scan our GitHub Actions Workflows
and open a Pull Request whenever new versions of the Actions
we use (e.g. styfle/cancel-workflow-action) are available.