### PR TITLE
fix: run pre-stop hook without su

### DIFF
--- a/templates/timescale.yaml
+++ b/templates/timescale.yaml
@@ -44,6 +44,7 @@ spec:
         runAsUser: 70
         runAsGroup: 70
         fsGroup: 70
+      terminationGracePeriodSeconds: 120
 {{- include "coder.serviceTolerations" . | indent 6 }}
       containers:
         - name: timescale
@@ -64,12 +65,10 @@ spec:
             preStop:
               exec:
                 command:
-                  - /bin/sh
-                  - -c
-                  - su
-                  - postgres
-                  - -c
-                  - "pg_ctl stop"
+                  - pg_ctl
+                  - stop
+                  - --mode=fast
+                  - --timeout=60
 {{- include "coder.resources" .Values.timescale.resources | indent 10 }}
   volumeClaimTemplates:
     - metadata:


### PR DESCRIPTION
* Change the hook to run "pg_ctl stop" without su, which already
  runs as the postgres user, since that's the Pod's runAsUser
* Explicitly define a terminationGracePeriodSeconds setting, set
  to 120 seconds, rather than relying on the default (30 seconds)

## Impact

This should stop the postgres database pod more quickly, while also doing so more safely than before.

## How I tested this

I installed this chart into my namespace on dev-2, used the following command to scale the StatefulSet up/down as needed:

```shell-session
kubectl scale statefulsets timescale --namespace coder-jawnsy-m --replicas 1
```

I then used the following command to watch for events:

```shell-session
kubectl get events --namespace=coder-jawnsy-m --watch
```

Here's the output using the Helm chart from master during container stop:

```
0s          Normal    Killing                  pod/timescale-0                                    Stopping container timescale
0s          Warning   FailedPreStopHook        pod/timescale-0                                    Exec lifecycle hook ([/bin/sh -c su postgres -c pg_ctl stop]) for Container "timescale" in Pod "timescale-0_coder-jawnsy-m(07d50216-a65f-4bca-823a-a9b055c74529)" failed - error: command '/bin/sh -c su postgres -c pg_ctl stop' exited with 1: Password: su: Authentication failure
, message: "Password: su: Authentication failure\n"
0s          Warning   Unhealthy                pod/timescale-0                                    Liveness probe failed: /var/run/postgresql:5432 - rejecting connections
0s          Warning   Unhealthy                pod/timescale-0                                    Liveness probe failed: /var/run/postgresql:5432 - rejecting connections
0s          Warning   Unhealthy                pod/timescale-0                                    Liveness probe failed: /var/run/postgresql:5432 - rejecting connections
```

Because the pg_ctl stop command fails, the container continues running until the database is abruptly terminated after the default `terminationGracePeriodSeconds` setting of 30 seconds. The next time the database starts, it'll have to recover any in-flight transactions. This is what it looks like after the change, note that the exit 137 is normal and indicates that the container died due to the running postgres daemon process terminating:

```
0s          Normal    Killing                  pod/timescale-0                                    Stopping container timescale
0s          Warning   FailedPreStopHook        pod/timescale-0                                    Exec lifecycle hook ([pg_ctl stop -w --mode=fast --timeout=60]) for Container "timescale" in Pod "timescale-0_coder-jawnsy-m(b56b3854-c6a3-4f0e-bcb3-f81aa5928778)" failed - error: command 'pg_ctl stop -w --mode=fast --timeout=60' exited with 137: , message: "waiting for server to shut down...."
0s          Warning   Unhealthy                pod/timescale-0                                    Liveness probe errored: rpc error: code = Unknown desc = container not running (0369e6b91dfa54720856da18785ff428bc5ae49824fd6fef456164f7ed9b054c)
```