### PR TITLE
chore: add coder.deployment label for PostgreSQL

### DIFF
--- a/templates/timescale.yaml
+++ b/templates/timescale.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: timescale
-    coder.deployment: postgresql
+    coder.deployment: timescale
 spec:
   ports:
     - port: 5432
@@ -34,7 +34,7 @@ spec:
     metadata:
       labels:
         app: timescale
-        coder.deployment: postgresql
+        coder.deployment: timescale
       annotations:
       {{- range $key, $value := .Values.deploymentAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -89,5 +89,5 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   name: timescale
   labels:
-    coder.deployment: postgresql
+    coder.deployment: timescale
 {{- end }}

--- a/templates/timescale.yaml
+++ b/templates/timescale.yaml
@@ -7,6 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: timescale
+    coder.deployment: postgresql
 spec:
   ports:
     - port: 5432
@@ -33,10 +34,11 @@ spec:
     metadata:
       labels:
         app: timescale
-      annotations:
-      {{- range $key, $value := .Values.deploymentAnnotations }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
+        coder.deployment: postgresql
+  annotations:
+  {{- range $key, $value := .Values.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
     spec:
       serviceAccountName: timescale
       securityContext:
@@ -86,4 +88,6 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace | quote }}
   name: timescale
+  labels:
+    coder.deployment: postgresql
 {{- end }}

--- a/templates/timescale.yaml
+++ b/templates/timescale.yaml
@@ -35,10 +35,10 @@ spec:
       labels:
         app: timescale
         coder.deployment: postgresql
-  annotations:
-  {{- range $key, $value := .Values.deploymentAnnotations }}
-    {{ $key }}: {{ $value | quote }}
-  {{- end }}
+      annotations:
+      {{- range $key, $value := .Values.deploymentAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
     spec:
       serviceAccountName: timescale
       securityContext:


### PR DESCRIPTION
Add a coder.deployment label to be consistent with other components,
to simplify our ce-diagnostics script.

# How I tested this

I used `make deploy` and then verified that the label appears on the timescale-0 pod:

```shell-session
[coder@jawnsy-m enterprise-helm]$ kubectl describe pod timescale-0
Name:         timescale-0
Namespace:    coder-jawnsy-m
Priority:     0
Node:         gke-dev-2-default-pool-cba3c583-0qyu/10.1.0.62
Start Time:   Thu, 18 Mar 2021 01:00:35 +0000
Labels:       app=timescale
              coder.deployment=postgresql
              controller-revision-hash=timescale-994689566
              statefulset.kubernetes.io/pod-name=timescale-0
Annotations:  cni.projectcalico.org/podIP: 10.8.3.226/32
```