### PR TITLE
chore: enforce kube-linter errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Lint Helm Chart
         run: make lint/helm
-        # TODO(jawnsy): fix linter warnings and remove this
-        continue-on-error: true
 
       - name: Check formatting and docs
         if: always()
@@ -38,8 +36,6 @@ jobs:
       - name: Lint Kubernetes Templates
         if: always()
         run: make lint/kubernetes
-        # TODO(jawnsy): fix linter warnings and remove this
-        continue-on-error: true
 
       - name: Package Helm Chart
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Lint Helm Chart
         run: make lint/helm
+        # TODO(jawnsy): fix linter warnings and remove this
+        continue-on-error: true
 
       - name: Check formatting and docs
         if: always()

--- a/.helmignore
+++ b/.helmignore
@@ -4,7 +4,7 @@
 .shellcheckrc
 build
 examples
-kube-linter
+kube-linter.yaml
 Makefile
 README.md.gotmpl
 scripts

--- a/.helmignore
+++ b/.helmignore
@@ -4,6 +4,7 @@
 .shellcheckrc
 build
 examples
-scripts
+kube-linter
 Makefile
 README.md.gotmpl
+scripts

--- a/kube-linter.yaml
+++ b/kube-linter.yaml
@@ -1,0 +1,23 @@
+checks:
+  include:
+    - dangling-service
+    - default-service-account
+    - deprecated-service-account-field
+    - drop-net-raw-capability
+    - env-var-secret
+    - mismatching-selector
+    - no-anti-affinity
+    - no-liveness-probe
+    - non-existent-service-account
+    - privileged-container
+    - run-as-non-root
+    - ssh-port
+    - writable-host-mount
+  exclude:
+    - no-extensions-v1beta
+    - no-read-only-root-fs
+    - no-readiness-probe
+    - required-annotation-email
+    - required-label-owner
+    - unset-cpu-requirements
+    - unset-memory-requirements

--- a/scripts/test_helm.sh
+++ b/scripts/test_helm.sh
@@ -29,4 +29,4 @@ for example in "${EXAMPLES[@]}"; do
     --output-dir="$BUILD" \| indent
 done
 
-run_trace false kube-linter lint "$BUILD"
+run_trace false kube-linter lint --config="$PROJECT_ROOT/kube-linter.yaml" "$BUILD"


### PR DESCRIPTION
* Suppress current failures by excluding them in kube-linter config
* Change GitHub Actions build to enforce lint failures