### PR TITLE
chore: security hardening for envproxy image

### DIFF
--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -45,6 +45,7 @@ spec:
     spec:
       # coder:coder
       securityContext:
+        runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
@@ -66,6 +67,9 @@ spec:
             - name: ssh-envproxy
               containerPort: 2222
 {{- end}}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
           # envproxy is a daemon service, no need to allocate a tty for it.
           tty: false
           env:


### PR DESCRIPTION
* Use a read-only root filesystem
* Drop privileges and prevent privilege escalation in the container

## How I tested this

I tested by running `make deploy` and verifying that envproxy is running and looks OK. I also verified that the mounts are mostly read-only.

```shell-session
[coder@jawnsy-m deploy]$ make deploy
Successfully packaged chart and saved it to: build/helm/pkg/coder-1.17.0-rc.2+65-g43b30c5ce-dirty.76969c3319-20210319.tgz
Release "coder" has been upgraded. Happy Helming!
NAME: coder
LAST DEPLOYED: Sun Mar 21 20:09:38 2021
NAMESPACE: coder-jawnsy-m
STATUS: deployed
REVISION: 6
TEST SUITE: None
[coder@jawnsy-m deploy]$ kubectl get pods
NAME                                        READY   STATUS    RESTARTS   AGE
cemanager-7899fff459-cd55q                  1/1     Running   0          41m
dashboard-95585688c-ncp2x                   1/1     Running   0          41m
envproxy-65648c9c65-ctrgj                   0/1     Running   0          33s
envproxy-7c99f646b-vwf28                    1/1     Running   0          41m
nginx-ingress-controller-5c856897cf-lpcmf   1/1     Running   0          3d19h
timescale-0                                 1/1     Running   0          30s
[coder@jawnsy-m deploy]$ kubectl logs envproxy-65648c9c65-ctrgj
2021-03-21 20:09:41.536 [INFO]  (envproxy)      <app.go:58>     initializing    {"version": "1.17.0-rc.2+65-g43b30c5ce-dirty.76969c3319-20210319", "mode": ""}
2021-03-21 20:09:41.538 [INFO]  (envproxy)      <app.go:69>     ensuring access to manager        {"cemanagerAccessURL": "http://cemanager.coder-jawnsy-m.svc.cluster.local:8080"}
2021-03-21 20:09:41.538 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 0, "total": 0, "deleted": 0, "dur_sec": 0.000001998}
2021-03-21 20:09:51.539 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 2, "total": 0, "deleted": 0, "dur_sec": 0.000008414}
2021-03-21 20:10:01.539 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 4, "total": 0, "deleted": 0, "dur_sec": 0.000006807}
2021-03-21 20:10:11.539 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 6, "total": 0, "deleted": 0, "dur_sec": 0.000008451}
2021-03-21 20:10:12.539 [INFO]  (envproxy)      <app.go:168>    ping failed, waiting for manager to be healthy
2021-03-21 20:10:12.558 [INFO]  (envproxy)      <app.go:78>     updating workspace provider config
2021-03-21 20:10:12.631 [INFO]  (envproxy)      <app.go:97>     successfully updated workspace provider
[coder@jawnsy-m deploy]$ kubectl logs envproxy-65648c9c65-ctrgj
2021-03-21 20:09:41.536 [INFO]  (envproxy)      <app.go:58>     initializing    {"version": "1.17.0-rc.2+65-g43b30c5ce-dirty.76969c3319-20210319", "mode": ""}
2021-03-21 20:09:41.538 [INFO]  (envproxy)      <app.go:69>     ensuring access to manager        {"cemanagerAccessURL": "http://cemanager.coder-jawnsy-m.svc.cluster.local:8080"}
2021-03-21 20:09:41.538 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 0, "total": 0, "deleted": 0, "dur_sec": 0.000001998}
2021-03-21 20:09:51.539 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 2, "total": 0, "deleted": 0, "dur_sec": 0.000008414}
2021-03-21 20:10:01.539 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 4, "total": 0, "deleted": 0, "dur_sec": 0.000006807}
2021-03-21 20:10:11.539 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 6, "total": 0, "deleted": 0, "dur_sec": 0.000008451}
2021-03-21 20:10:12.539 [INFO]  (envproxy)      <app.go:168>    ping failed, waiting for manager to be healthy
2021-03-21 20:10:12.558 [INFO]  (envproxy)      <app.go:78>     updating workspace provider config
2021-03-21 20:10:12.631 [INFO]  (envproxy)      <app.go:97>     successfully updated workspace provider
2021-03-21 20:10:21.539 [DEBUG] (envproxy.proxysdk)     <prune.go:96>   prune   {"op": "mcache prune", "cache": "proxysdk", "iter": 8, "total": 2, "deleted": 0, "dur_sec": 0.000014483}
coder@jawnsy-m enterprise-helm]$ kubectl exec -it envproxy-65648c9c65-ctrgj -- mount
overlay on / type overlay (ro,relatime,lowerdir=/var/lib/docker/overlay2/l/GVDW2HSBTQH4XUVT6PZTSVORVL:/var/lib/docker/overlay2/l/Y35WM52R2VL642BS6KBKSN6BZM:/var/lib/docker/overlay2/l/DLWVMYRAGE3GGTOKIFCMSIU3HC:/var/lib/docker/overlay2/l/WUCCDV2J4I5ZXROZMVWEHBWS2Q:/var/lib/docker/overlay2/l/ZZSUEQ5KO6VD6HNDG5WOYG6EJC:/var/lib/docker/overlay2/l/QSY2DF2FYTN4OBPDVVTNHNWIST:/var/lib/docker/overlay2/l/X7D6DTRNS2NICUOYDOCXJGK6WV:/var/lib/docker/overlay2/l/KHDQQB5P3ODJJOX5IJOROJNTAJ:/var/lib/docker/overlay2/l/T3Q5EKBSYB4KHAVVOWSO7PFNQQ:/var/lib/docker/overlay2/l/DZXTPEA22MSDTPLVIB6G6NGZKH:/var/lib/docker/overlay2/l/C2N3PVNT3BZKM4V5BJ2SEIAZOW:/var/lib/docker/overlay2/l/T5BK6AMXYMQ5BKMDJGRT4JVTKK:/var/lib/docker/overlay2/l/D3ACM6PRQFW5IBTWSFDQ4YIJM2:/var/lib/docker/overlay2/l/4UVJWCN4MLKW6PRSNMRQIUERLL:/var/lib/docker/overlay2/l/CRXYWREOZQM7XFDLJTENMC5LVP:/var/lib/docker/overlay2/l/DKX33YWBGK5AT4M7X46CPSRF77:/var/lib/docker/overlay2/l/44NVD7OVQ4YVZBJAQOHNIY3K3B:/var/lib/docker/overlay2/l/A6KHQS7ME2PU5HWRFGJWKONPMT,upperdir=/var/lib/docker/overlay2/3f198b06e85494a23db784127a7941d9793867acf5abb75097bd22d934ac93e2/diff,workdir=/var/lib/docker/overlay2/3f198b06e85494a23db784127a7941d9793867acf5abb75097bd22d934ac93e2/work,xino=off)
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
tmpfs on /dev type tmpfs (rw,nosuid,size=65536k,mode=755)
devpts on /dev/pts type devpts (rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=666)
sysfs on /sys type sysfs (ro,nosuid,nodev,noexec,relatime)
tmpfs on /sys/fs/cgroup type tmpfs (ro,nosuid,nodev,noexec,relatime,mode=755)
cgroup on /sys/fs/cgroup/systemd type cgroup (ro,nosuid,nodev,noexec,relatime,xattr,name=systemd)
cgroup on /sys/fs/cgroup/rdma type cgroup (ro,nosuid,nodev,noexec,relatime,rdma)
cgroup on /sys/fs/cgroup/cpu,cpuacct type cgroup (ro,nosuid,nodev,noexec,relatime,cpu,cpuacct)
cgroup on /sys/fs/cgroup/net_cls,net_prio type cgroup (ro,nosuid,nodev,noexec,relatime,net_cls,net_prio)
cgroup on /sys/fs/cgroup/freezer type cgroup (ro,nosuid,nodev,noexec,relatime,freezer)
cgroup on /sys/fs/cgroup/perf_event type cgroup (ro,nosuid,nodev,noexec,relatime,perf_event)
cgroup on /sys/fs/cgroup/cpuset type cgroup (ro,nosuid,nodev,noexec,relatime,cpuset)
cgroup on /sys/fs/cgroup/pids type cgroup (ro,nosuid,nodev,noexec,relatime,pids)
cgroup on /sys/fs/cgroup/blkio type cgroup (ro,nosuid,nodev,noexec,relatime,blkio)
cgroup on /sys/fs/cgroup/devices type cgroup (ro,nosuid,nodev,noexec,relatime,devices)
cgroup on /sys/fs/cgroup/memory type cgroup (ro,nosuid,nodev,noexec,relatime,memory)
cgroup on /sys/fs/cgroup/hugetlb type cgroup (ro,nosuid,nodev,noexec,relatime,hugetlb)
mqueue on /dev/mqueue type mqueue (rw,nosuid,nodev,noexec,relatime)
/dev/sda1 on /dev/termination-log type ext4 (rw,relatime)
/dev/sda1 on /etc/resolv.conf type ext4 (ro,relatime)
/dev/sda1 on /etc/hostname type ext4 (ro,relatime)
/dev/sda1 on /etc/hosts type ext4 (rw,relatime)
shm on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime,size=65536k)
tmpfs on /run/secrets/kubernetes.io/serviceaccount type tmpfs (ro,relatime)
proc on /proc/bus type proc (ro,relatime)
proc on /proc/fs type proc (ro,relatime)
proc on /proc/irq type proc (ro,relatime)
proc on /proc/sys type proc (ro,relatime)
proc on /proc/sysrq-trigger type proc (ro,relatime)
tmpfs on /proc/acpi type tmpfs (ro,relatime)
tmpfs on /proc/kcore type tmpfs (rw,nosuid,size=65536k,mode=755)
tmpfs on /proc/keys type tmpfs (rw,nosuid,size=65536k,mode=755)
tmpfs on /proc/timer_list type tmpfs (rw,nosuid,size=65536k,mode=755)
tmpfs on /proc/sched_debug type tmpfs (rw,nosuid,size=65536k,mode=755)
tmpfs on /proc/scsi type tmpfs (ro,relatime)
tmpfs on /sys/firmware type tmpfs (ro,relatime)
```