### PR TITLE
chore: rename instances of Coder Enterprise to Coder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coder Enterprise Helm
+# Coder Helm
 
 WARNING: The master branch may contain updates for a yet unreleased version of
 Coder. The current state of the repo may not represent the latest release.

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -1,4 +1,4 @@
-# Coder Enterprise Helm
+# Coder Helm
 
 WARNING: The master branch may contain updates for a yet unreleased version of
 Coder. The current state of the repo may not represent the latest release.

--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -1,6 +1,6 @@
-# The following describes the Kubernetes deployment of the Coder Enterprise
-# manager. The general setup is as follows:
-#   - A namespace contains all the relevant resources for Coder Enterprise.
+# The following describes the Kubernetes deployment of the Coder service.
+# The general setup is as follows:
+#   - A namespace contains all the relevant resources for Coder.
 #   - A deployment describes the configuration of the manager container.
 #   - A service is created to route requests to the manager pod.
 #   - A service account (along with a Role and Role binding) is created to grant


### PR DESCRIPTION
We rebranded the product from Coder Enterprise to Coder; this change
updates the text accordingly. Some references (such as URLs and
variable names) have not been changed.