### PR TITLE
Remove hardcoded /proxy path from built-in wsp

### DIFF
--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -100,7 +100,7 @@ tolerations:
     {{- else -}}
     http://
     {{- end -}}
-    {{- .Values.ingress.host }}/proxy
+    {{- .Values.ingress.host }}
 {{- else }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
I originally didn't know where this was coming from, and thought that we just had the data in the DB from 1.16 previously, but when digging around I saw that we still hard code the `/proxy` path for built-in WSPs. This will set it to just the hostname and will apply on deployment. 