### PR TITLE
update ingress external traffic policy

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -315,7 +315,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
   type: LoadBalancer
   loadBalancerIP: {{ .Values.ingress.loadBalancerIP | quote }}
   selector:


### PR DESCRIPTION
changing ingress `externalTrafficPolicy` value from `Local` to `Cluster`, as it fixes the issue with AWS ELB not forwarding traffic to a node that has the nginx ingress instance running, as documented [here](https://app.clubhouse.io/coder/story/9632/eks-load-balancer-is-running-but-status-says-it-s-out-of-service-and-doesn-t-route-traffic).

a customer found this solution from this [GitLab issue](https://gitlab.com/gitlab-org/charts/gitlab/-/issues/939). only issue is that it's making the IP addresses of the routed traffic private, which removes the ability for our audit logs to properly identify people.

submitting this PR to open up the discussion.