### PR TITLE
chore: Remove envbuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ form](https://coder.com/contact) or send an email to support@coder.com.
 | deploymentAnnotations | object |  | `{}` |
 | devurls.host | string | Should be a wildcard hostname to allow matching against custom-created dev URLs. Leaving as an empty string results in devurls being disabled. Example: "*.devurls.coder.com". | `""` |
 | envbox.image | string | Injected during releases. | `""` |
-| envbuilder.image | string | Injected during releases. | `""` |
 | environments.nodeSelector | object | nodeSelector is applied to all user environments to specify eligible nodes for environments to run on. See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector  eg. nodeSelector:   disktype: ssd | `{}` |
 | environments.tolerations | list | Tolerations are applied to all user environments. Each element is a regular pod toleration object. To set service tolerations see serviceTolerations. See values.yaml for an example. | `[]` |
 | envproxy.accessURL | string | The URL reported to cemanager. Must be accessible by cemanager and all users who can use this workspace provider. This should be a full URL, complete with protocol and trailing "/proxy" (no trailing slash). This is derived from the ingress.host or the access URL set during cemanager setup if not set. e.g. "https://proxy.coder.com/proxy" | `""` |

--- a/examples/images.yaml
+++ b/examples/images.yaml
@@ -9,5 +9,3 @@ timescale:
   image: gcr.io/coder/timescale:2.0.0
 envbox:
   image: gcr.io/coder/envbox:2.0.0
-envbuilder:
-  image: gcr.io/coder/envbuilder:2.0.0

--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -100,11 +100,6 @@ spec:
               value: {{ .Values.logging.json | quote }}
             - name: STACKDRIVER_LOG
               value: {{ .Values.logging.stackdriver | quote }}
-              # ENVBUILDER_IMAGE describes the image used to build
-              # user images and populate them with coder assets
-              # (such as code-server).
-            - name: ENVBUILDER_IMAGE
-              value: {{ .Values.envbuilder.image | quote }}
               # ENVBOX_IMAGE describes the image used to provide
               # additional features to users for running applications
               # such as dockerd and kubernetes.

--- a/values.yaml
+++ b/values.yaml
@@ -250,10 +250,6 @@ envbox:
   # envbox.image -- Injected during releases.
   image: ""
 
-envbuilder:
-  # envbuilder.image -- Injected during releases.
-  image: ""
-
 # environments defines configuration that is applied to all
 # user environments.
 environments:


### PR DESCRIPTION
We should be cautious merging this. We'll need to document the removal of envbuilder, as I'd assume helm will throw an error if a customer keeps this value.