### PR TITLE
feat: configurable ingress externalTrafficPolicy and deploy kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,15 @@ form](https://coder.com/contact) or send an email to support@coder.com.
 | imagePullPolicy | string | Sets the policy for pulling a container image across all services. | `"Always"` |
 | ingress.additionalAnnotations | list | Deprecated. Please use `ingress.annotations`. | `[]` |
 | ingress.annotations | object | Additional annotations to be used when creating the ingress. These only apply to the Ingress Kubernetes kind. The annotations can be used to specify certificate issuers or other cloud provider-specific integrations. | `{}` |
+| ingress.deployment | object | Options used to configure the Deployment of the default ingress controller. | `{"kind":"Deployment"}` |
+| ingress.deployment.kind | string | How to deploy the built-in ingress. Can be "Deployment" or "DaemonSet". | `"Deployment"` |
 | ingress.enable | bool | If set to true, a Coder compatible ingress kind will be created. You can configure it with `ingress.annotations` below. | `true` |
 | ingress.host | string | The hostname to use for accessing the platform. This can be left blank, and the user can still access the platform from the external IP or a DNS name that resolves to the external IP address. | `""` |
 | ingress.loadBalancerIP | string |  | `""` |
 | ingress.podSecurityPolicyName | string | The name of the pod security policy the built-in ingress controller should abide. It should be noted that the ingress controller requires the `NET_BIND_SERVICE` capability, privilege escalation, and access to privileged ports to successfully deploy. Ignored if `ingress.useDefault` is false. | `""` |
-| ingress.service | object | Options related to the ingress Kubernetes Service object. | `{"annotations":{}}` |
+| ingress.service | object | Options used to configure the LoadBalancer Service used in the default ingress controller. | `{"annotations":{},"externalTrafficPolicy":"Local"}` |
 | ingress.service.annotations | object | Additional annotations to add to the Service object. For example, to make the ingress spawn an internal load balancer: annotations:  cloud.google.com/load-balancer-type: "Internal" | `{}` |
+| ingress.service.externalTrafficPolicy | string | Denotes whether to route external traffic to node-local or cluster-wide endpoints. "Local" routes external traffic directly to the correct node, while "Cluster" evenly distributes traffic across all nodes, but masks source IPs. | `"Local"` |
 | ingress.tls | object | TLS options for the ingress. The hosts used for the tls configuration come from the ingress.host and the devurls.host variables. If those don't exist, then the TLS configuration will be ignored. | `{"devurlsHostSecretName":"","enable":false,"hostSecretName":""}` |
 | ingress.tls.devurlsHostSecretName | string | The secret to use for the devurls.host hostname. | `""` |
 | ingress.tls.enable | bool | Enables the tls configuration. | `false` |

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -203,7 +203,7 @@ subjects:
     namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ .Values.ingress.deployment.kind | quote }}
 metadata:
   name: nginx-ingress-controller
   namespace: {{ .Release.Namespace | quote }}
@@ -215,7 +215,9 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
+{{- if eq .Values.ingress.deployment.kind "Deployment" }}
   replicas: 1
+{{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: ingress-nginx
@@ -314,7 +316,7 @@ metadata:
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: {{ .Values.ingress.externalTrafficPolicy | quote }}
   type: LoadBalancer
   loadBalancerIP: {{ .Values.ingress.loadBalancerIP | quote }}
   selector:
@@ -337,7 +339,7 @@ spec:
     - name: turns
       port: 5349
       targetPort: 5349
-{{- end}}
+{{- end }}
 {{- end }}
 {{- if or .Values.ingress.useDefault .Values.ingress.enable }}
 ---

--- a/values.yaml
+++ b/values.yaml
@@ -68,13 +68,25 @@ ingress:
     # ingress.tls.devurlsHostSecretName -- The secret to use for the
     # devurls.host hostname.
     devurlsHostSecretName: ""
-  # ingress.service -- Options related to the ingress Kubernetes Service object.
+  # ingress.service -- Options used to configure the LoadBalancer Service used
+  # in the default ingress controller.
   service:
     # ingress.service.annotations -- Additional annotations to add to the Service
     # object. For example, to make the ingress spawn an internal load balancer:
     # annotations:
     #  cloud.google.com/load-balancer-type: "Internal"
     annotations: {}
+    # ingress.service.externalTrafficPolicy -- Denotes whether to route external
+    # traffic to node-local or cluster-wide endpoints. "Local" routes external
+    # traffic directly to the correct node, while "Cluster" evenly distributes
+    # traffic across all nodes, but masks source IPs.
+    externalTrafficPolicy: Local
+  # ingress.deployment -- Options used to configure the Deployment of the
+  # default ingress controller.
+  deployment:
+  # ingress.deployment.kind -- How to deploy the built-in ingress. Can be
+  # "Deployment" or "DaemonSet".
+    kind: Deployment
 
 devurls:
   # devurls.host -- Should be a wildcard hostname to allow matching against


### PR DESCRIPTION
Allows configuring two new variables

`ingress.service.externalTrafficPolicy`: It was found that setting this to `Local` causes issues in EKS, and it was changed to `Cluster` in https://github.com/cdr/enterprise-helm/pull/63. This changes the default back to `Local` since this is the most sensible default, and makes it configurable.

`ingress.deployment.kind`: In deployments that use `externalTrafficPolicy: Cluster`, the user's IP becomes masked by kube-proxy. This allows ingress-nginx to be deployed as a `DaemonSet` to prevent this.