### PR TITLE
Make readOnlyRootFilesystem configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ form](https://coder.com/contact) or send an email to support@coder.com.
 | cemanager.image | string | Injected during releases. | `""` |
 | cemanager.replicas | int | The number of replicas to run of the manager. | `1` |
 | cemanager.resources | object | Kubernetes resource request and limits for cemanager pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
+| cemanager.securityContext | object | Contains fields related to the cemanager container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
 | cemanager.turn | object | turn contains configuration related to running a TURN server on port 5349 NOTE: This is an alpha feature and is prone to breaking changes. | `{"enable":false}` |
 | cemanager.turn.enable | bool | enables the TURN server and allows networking V2 alpha to be enabled in site config. | `false` |
 | certs | object | Describes CAs that should be added to Coder services. These certs are NOT added to environments. | `{"secret":{"key":"","name":""}}` |
@@ -59,6 +60,7 @@ form](https://coder.com/contact) or send an email to support@coder.com.
 | envproxy.image | string | Injected during releases. | `""` |
 | envproxy.replicas | int | The number of replicas to run of the envproxy. | `1` |
 | envproxy.resources | object | Kubernetes resource request and limits for envproxy pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
+| envproxy.securityContext | object | Contains fields related to the envproxy container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
 | envproxy.terminationGracePeriodSeconds | int | Amount of seconds to wait before shutting down the environment proxy if there are still open connections. This is set very long intentionally so developers do not deal with disconnects during deployments. | `14400` |
 | imagePullPolicy | string | Sets the policy for pulling a container image across all services. | `"Always"` |
 | ingress.additionalAnnotations | list | Deprecated. Please use `ingress.annotations`. | `[]` |

--- a/kube-linter.yaml
+++ b/kube-linter.yaml
@@ -11,10 +11,10 @@ checks:
     - no-readiness-probe
     - non-existent-service-account
     - privileged-container
+    - read-only-root-fs
     - run-as-non-root
     - ssh-port
     - writable-host-mount
-    - read-only-root-fs
   exclude:
     - no-extensions-v1beta
     - required-annotation-email

--- a/kube-linter.yaml
+++ b/kube-linter.yaml
@@ -8,10 +8,10 @@ checks:
     - mismatching-selector
     - no-anti-affinity
     - no-liveness-probe
+    - no-read-only-root-fs
     - no-readiness-probe
     - non-existent-service-account
     - privileged-container
-    - read-only-root-fs
     - run-as-non-root
     - ssh-port
     - writable-host-mount

--- a/kube-linter.yaml
+++ b/kube-linter.yaml
@@ -14,9 +14,9 @@ checks:
     - run-as-non-root
     - ssh-port
     - writable-host-mount
+    - read-only-root-fs
   exclude:
     - no-extensions-v1beta
-    - no-read-only-root-fs
     - required-annotation-email
     - required-label-owner
     - unset-cpu-requirements

--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -90,6 +90,9 @@ spec:
           ports:
             - name: tcp-cemanager
               containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRooFilesystem: {{ .Values.cemanager.securityContext.readOnlyRootFilesystem }}
           # cemanager is a daemon service, no need to allocate a tty for it.
           tty: false
           env:

--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -92,7 +92,7 @@ spec:
               containerPort: 8080
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRooFilesystem: {{ .Values.cemanager.securityContext.readOnlyRootFilesystem }}
+            readOnlyRootFilesystem: {{ .Values.cemanager.securityContext.readOnlyRootFilesystem }}
           # cemanager is a daemon service, no need to allocate a tty for it.
           tty: false
           env:

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -70,7 +70,7 @@ spec:
 {{- end}}
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: {{ .Values.envproxy.securityContext.readOnlyRootFilesystem }}
           # envproxy is a daemon service, no need to allocate a tty for it.
           tty: false
           env:

--- a/values.yaml
+++ b/values.yaml
@@ -143,6 +143,13 @@ cemanager:
   replicas: 1
   # cemanager.image -- Injected during releases.
   image: ""
+  # cemanager.securityContext -- Contains fields related to the cemanager
+  # container's security context (as opposed to the pod).
+  securityContext:
+    # cemanager.securityContext.readonlyRootFilesystem -- Sets the root filesystem
+    # of the cemanager container to read-only. It is recommended to leave this setting enabled
+    # in production.
+    readOnlyRootFilesystem: true
   # cemanager.resources -- Kubernetes resource request and limits for cemanager
   # pods.
   # To unset a value, set it to "".
@@ -185,6 +192,13 @@ envproxy:
   replicas: 1
   # envproxy.image -- Injected during releases.
   image: ""
+  # envproxy.securityContext -- Contains fields related to the envproxy
+  # container's security context (as opposed to the pod).
+  securityContext:
+    # envproxy.securityContext.readonlyRootFilesystem -- Sets the root filesystem
+    # of the envproxy container to read-only. It is recommended to leave this setting enabled
+    # in production.
+    readOnlyRootFilesystem: true
   # envproxy.resources -- Kubernetes resource request and limits for envproxy
   # pods.
   # To unset a value, set it to "".


### PR DESCRIPTION
This PR makes the `readOnlyRootFilesystem` field configurable via the `values.yaml`. It is enabled by default. 