### PR TITLE
feat: expose port 8443 on ce-manager for https

### DIFF
--- a/templates/cemanager.yaml
+++ b/templates/cemanager.yaml
@@ -177,6 +177,9 @@ spec:
     - name: tcp-cemanager
       port: 8080
       protocol: TCP
+    - name: tcp-cemanager-https
+      port: 8443
+      protocol: TCP
     - name: tcp-cemanager-turns
       port: 5349
       protocol: TCP


### PR DESCRIPTION
Helm updates to support https://github.com/cdr/m/pull/8248