### PR TITLE
ci: rename master branch to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,12 @@ name: build
 on:
   push:
     branches:
-      - master
+      - main
+
   pull_request:
     branches:
-      - master
+      - main
+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Rename master to main in the GitHub Actions workflow.