### PR TITLE
chore: Add dashboard image back with cemanager replica

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ form](https://coder.com/contact) or send an email to support@coder.com.
 | certs.secret.key | string | The key in the secret pointing to the certificate bundle. | `""` |
 | certs.secret.name | string | The name of the secret. | `""` |
 | clusterDomainSuffix | string | If you've set a custom default domain for your cluster, you may need to remove or change this DNS suffix for service resolution to work correctly. | `".svc.cluster.local"` |
+| dashboard.image | string | Injected during releases. | `""` |
+| dashboard.replicas | int | The number of replicas to run of the dashboard. | `1` |
+| dashboard.resources | object | Kubernetes resource request and limits for dashboard pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
 | deploymentAnnotations | object |  | `{}` |
 | devurls.host | string | Should be a wildcard hostname to allow matching against custom-created dev URLs. Leaving as an empty string results in devurls being disabled. Example: "*.devurls.coder.com". | `""` |
 | envbox.image | string | Injected during releases. | `""` |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ form](https://coder.com/contact) or send an email to support@coder.com.
 | dashboard.image | string | Injected during releases. | `""` |
 | dashboard.replicas | int | The number of replicas to run of the dashboard. | `1` |
 | dashboard.resources | object | Kubernetes resource request and limits for dashboard pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
+| dashboard.securityContext | object | Contains fields related to the dashboard container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
 | deploymentAnnotations | object |  | `{}` |
 | devurls.host | string | Should be a wildcard hostname to allow matching against custom-created dev URLs. Leaving as an empty string results in devurls being disabled. Example: "*.devurls.coder.com". | `""` |
 | envbox.image | string | Injected during releases. | `""` |

--- a/examples/images.yaml
+++ b/examples/images.yaml
@@ -1,6 +1,8 @@
 # Dummy image tags
 cemanager:
   image: gcr.io/coder/coder-service:2.0.0
+dashboard:
+  image: gcr.io/coder/coder-service:2.0.0
 envproxy:
   image: gcr.io/coder/envproxy:2.0.0
 timescale:

--- a/examples/kind/kind.values.yaml
+++ b/examples/kind/kind.values.yaml
@@ -8,6 +8,12 @@ cemanager:
       cpu: 100m
       memory: 64Mi
 
+dashboard:
+  resources:
+    requests:
+      cpu: 0m
+      memory: 16Mi
+
 envproxy:
   resources:
     requests:

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    coder.deployment: dashboard
+  name: dashboard
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+  {{- range $key, $value := .Values.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.dashboard.replicas }}
+  strategy:
+    rollingUpdate:
+      maxSurge: "25%"
+      maxUnavailable: "25%"
+  selector:
+    matchLabels:
+      coder.deployment: dashboard
+  template:
+    metadata:
+      labels:
+        coder.deployment: dashboard
+      annotations:
+      {{- range $key, $value := .Values.deploymentAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+    spec:
+      # coder:coder
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      restartPolicy: Always
+      serviceAccountName: dashboard
+{{- include "coder.services.nodeSelector" . | indent 6 }}
+{{- include "coder.serviceTolerations" . | indent 6 }}
+      containers:
+        - name: dashboard
+          image: {{ .Values.cemanager.image | quote }}
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          ports:
+            - name: tcp-dashboard
+              containerPort: 3000
+          # dashboard runs a node server. no tty is needed for it.
+          tty: false
+          env:
+            - name: CEMANAGER_HOST
+              value: "http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix}}:8080"
+          command:
+            - /bin/bash
+            - -c
+            - |
+              exec cemanager replica --bind 0.0.0.0:3000 --main-url $CEMANAGER_HOST 
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 3000
+            initialDelaySeconds: 10
+            failureThreshold: 7
+            periodSeconds: 10
+{{- include "coder.resources" .Values.dashboard.resources | indent 10 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dashboard
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  type: {{ .Values.serviceType | quote }}
+  selector:
+    coder.deployment: dashboard
+  ports:
+    - name: tcp-dashboard
+      port: 3000
+      protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace | quote }}
+  name: dashboard

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -44,6 +44,9 @@ spec:
           ports:
             - name: tcp-dashboard
               containerPort: 3000
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: {{ .Values.dashboard.securityContext.readOnlyRootFilesystem }}
           # dashboard runs a node server. no tty is needed for it.
           tty: false
           env:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -384,10 +384,18 @@ spec:
         backend:
           serviceName: envproxy
           servicePort: 8080
-      - path: /
+      - path: /api/
         backend:
           serviceName: cemanager
           servicePort: 8080
+      - path: /auth/
+        backend:
+          serviceName: cemanager
+          servicePort: 8080
+      - path: /
+        backend:
+          serviceName: dashboard
+          servicePort: 3000
     {{- if ne .Values.devurls.host "" }}
   - host: {{ .Values.devurls.host | quote }}
     http:
@@ -402,10 +410,18 @@ spec:
         backend:
           serviceName: envproxy
           servicePort: 8080
-      - path: /*
+      - path: /api/*
         backend:
           serviceName: cemanager
           servicePort: 8080
+      - path: /auth/*
+        backend:
+          serviceName: cemanager
+          servicePort: 8080
+      - path: /*
+        backend:
+          serviceName: dashboard
+          servicePort: 3000
     {{- if ne .Values.devurls.host "" }}
   - host: {{ .Values.devurls.host | quote }}
     http:

--- a/values.yaml
+++ b/values.yaml
@@ -180,6 +180,13 @@ dashboard:
   replicas: 1
   # dashboard.image -- Injected during releases.
   image: ""
+  # dashboard.securityContext -- Contains fields related to the dashboard
+  # container's security context (as opposed to the pod).
+  securityContext:
+    # dashboard.securityContext.readonlyRootFilesystem -- Sets the root filesystem
+    # of the dashboard container to read-only. It is recommended to leave this setting enabled
+    # in production.
+    readOnlyRootFilesystem: true
   # dashboard.resources -- Kubernetes resource request and limits for dashboard
   # pods.
   # To unset a value, set it to "".

--- a/values.yaml
+++ b/values.yaml
@@ -174,6 +174,31 @@ cemanager:
     # cemanager.turn.enable -- enables the TURN server and allows networking V2 alpha to be enabled in site config.
     enable: false
 
+# Contains the user interface of the platform.
+dashboard:
+  # dashboard.replicas -- The number of replicas to run of the dashboard.
+  replicas: 1
+  # dashboard.image -- Injected during releases.
+  image: ""
+  # dashboard.resources -- Kubernetes resource request and limits for dashboard
+  # pods.
+  # To unset a value, set it to "".
+  # To unset all values, you can provide a values.yaml file which sets resources
+  # to nil. See values.yaml for an example.
+  #
+  # e.g:
+  # dashboard:
+  #   # This will cause all values to be unset.
+  #   resources:
+  #   replica: 1
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "250m"
+      memory: "512Mi"
+
 # envproxy contains configuration for the service handling long-lived
 # connections to environments such as IDE or shell sessions.
 envproxy:


### PR DESCRIPTION
We aren't deprecating the dashboard until next release, so for now we can use a cemanager replica to essentially perform the same function.