### PR TITLE
fix: Move notes to templates/notes

### DIFF
--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,4 +1,0 @@
-Thank you for installing {{ .Chart.Name }}.
-
-For more information on configuration see values.yaml in the package
-`helm pull <repo>/{{ .Chart.Name}} {{ .Chart.Version }}`.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | ingress.tls.devurlsHostSecretName | string | The secret to use for the devurls.host hostname. | `""` |
 | ingress.tls.enable | bool | Enables the tls configuration. | `false` |
 | ingress.tls.hostSecretName | string | The secret to use for the ingress.host hostname. | `""` |
-| ingress.useDefault | bool | If set to true, will deploy an nginx ingress that will allow you to access Coder from an external IP address, but only if your kubernetes cluster is configured to provision external IP addresses. If you would like to bring your own ingress and hook Coder into that instead, set this value to false. | `true` |
+| ingress.useDefault | bool | If set to true, will deploy an nginx ingress that will allow you to access Coder from an external IP address, but only if your kubernetes cluster is configured to provision external IP addresses. If you would like to bring your own ingress and hook Coder into that instead, set this value to false. | `false` |
 | ingress.usePathWildcards | bool | Whether or not the ingress object should use path wildcards, i.e., ending with "/*". Some ingresses require this while others do not. You should check which path style your ingress requires. For ingress-nginx this should be set to false. | `false` |
 | logging.human | string | Where to send logs that are formatted for readability by a human. Set to an empty string to disable. | `"/dev/stderr"` |
 | logging.json | string | Where to send logs that are formatted as JSON. Set to an empty string to disable. | `""` |
@@ -105,6 +105,8 @@ Helm compiles templates with `values.yaml` when deploying.
 ```shell-session
 $ make README.md
 ```
+
+Deprecation notices should be added to `templates/NOTES.txt`.
 
 ## Support
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -35,6 +35,8 @@ Helm compiles templates with `values.yaml` when deploying.
 $ make README.md
 ```
 
+Deprecation notices should be added to `templates/NOTES.txt`.
+
 ## Support
 
 If you experience issues, have feedback, or want to ask a question, open an issue or

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,0 +1,12 @@
+
+{{- if .Values.ingress.additionalAnnotations }}
+Warning: `ingress.additionalAnnotations` has been moved to `ingress.annotations`.
+{{- end }}
+
+{{- if .Values.namespaceWhitelist }}
+Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers instead. See: https://coder.com/docs/admin/workspace-providers
+{{- end }}
+
+{{- if .Values.dashboard }}
+Warning: `dashboard` is being merged with `cemanager` in a future release. If you are using a custom ingress, redirect all `dashboard` traffic to `cemanager`.
+{{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -8,7 +8,7 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 
 {{- if .Values.dashboard }}
 Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021). You can safely delete the `dashboard` property.
-{{- if eq .Values.ingress.useDefault true }}
+{{- if eq .Values.ingress.useDefault false }}
 
 Breaking: All `dashboard` traffic should be routed to `cemanager` before v1.21.
 {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,4 +1,3 @@
-
 {{- if .Values.ingress.additionalAnnotations }}
 Warning: `ingress.additionalAnnotations` has been moved to `ingress.annotations`.
 {{- end }}
@@ -8,5 +7,9 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 {{- end }}
 
 {{- if .Values.dashboard }}
-Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021). If you are using a custom ingress, redirect all `dashboard` traffic to `cemanager`. You can safely delete the `dashboard` property.
+Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021). You can safely delete the `dashboard` property.
+{{- if eq .Values.ingress.useDefault true }}
+
+Breaking: All `dashboard` traffic should be routed to `cemanager` before v1.21.
+{{- end }}
 {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -8,5 +8,5 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 {{- end }}
 
 {{- if .Values.dashboard }}
-Warning: `dashboard` is being merged with `cemanager` in a future release. If you are using a custom ingress, redirect all `dashboard` traffic to `cemanager`.
+Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021). If you are using a custom ingress, redirect all `dashboard` traffic to `cemanager`. You can safely delete the `dashboard` property.
 {{- end }}


### PR DESCRIPTION
Notes were never actually outputted before... now customers can detect deprecation notices when upgrading!

Run the following to test it out yourself:

```shell-session
$ helm install --dry-run --debug coder ./
```

![image](https://user-images.githubusercontent.com/7122116/119244191-97d55980-bb33-11eb-94c6-0b96f9ed81f1.png)