### PR TITLE
chore: Migrate cemanager to coderd

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,22 +33,11 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | coderd.securityContext | object | Contains fields related to the coderd container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
 | coderd.turn | object | turn contains configuration related to running a TURN server on port 5349 NOTE: This is an alpha feature and is prone to breaking changes. | `{"enable":false}` |
 | coderd.turn.enable | bool | enables the TURN server and allows networking V2 alpha to be enabled in site config. | `false` |
-| dashboard.image | string | Injected during releases. | `""` |
-| dashboard.replicas | int | The number of replicas to run of the dashboard. | `1` |
-| dashboard.resources | object | Kubernetes resource request and limits for dashboard pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
-| dashboard.securityContext | object | Contains fields related to the dashboard container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
 | deploymentAnnotations | object |  | `{}` |
 | devurls.host | string | Should be a wildcard hostname to allow matching against custom-created dev URLs. Leaving as an empty string results in devurls being disabled. Example: "*.devurls.coder.com". | `""` |
 | envbox.image | string | Injected during releases. | `""` |
 | environments.nodeSelector | object | nodeSelector is applied to all user environments to specify eligible nodes for environments to run on. See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector  eg. nodeSelector:   disktype: ssd | `{}` |
 | environments.tolerations | list | Tolerations are applied to all user environments. Each element is a regular pod toleration object. To set service tolerations see serviceTolerations. See values.yaml for an example. | `[]` |
-| envproxy.accessURL | string | The URL reported to coderd. Must be accessible by coderd and all users who can use this workspace provider. This should be a full URL, complete with protocol and trailing "/proxy" (no trailing slash). This is derived from the ingress.host or the access URL set during coderd setup if not set. e.g. "https://proxy.coder.com/proxy" | `""` |
-| envproxy.clusterAddress | string | The address of the K8s cluster, must be reachable from the coderd. Defaults to "https://kubernetes.default.$clusterDomainSuffix:443" if not set. | `""` |
-| envproxy.image | string | Injected during releases. | `""` |
-| envproxy.replicas | int | The number of replicas to run of the envproxy. | `1` |
-| envproxy.resources | object | Kubernetes resource request and limits for envproxy pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
-| envproxy.securityContext | object | Contains fields related to the envproxy container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
-| envproxy.terminationGracePeriodSeconds | int | Amount of seconds to wait before shutting down the environment proxy if there are still open connections. This is set very long intentionally so developers do not deal with disconnects during deployments. | `14400` |
 | imagePullPolicy | string | Sets the policy for pulling a container image across all services. | `"Always"` |
 | ingress.additionalAnnotations | list | Deprecated. Please use `ingress.annotations`. | `[]` |
 | ingress.annotations | object | Additional annotations to be used when creating the ingress. These only apply to the Ingress Kubernetes kind. The annotations can be used to specify certificate issuers or other cloud provider-specific integrations. | `{}` |
@@ -66,7 +55,7 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | ingress.tls.devurlsHostSecretName | string | The secret to use for the devurls.host hostname. | `""` |
 | ingress.tls.enable | bool | Enables the tls configuration. | `false` |
 | ingress.tls.hostSecretName | string | The secret to use for the ingress.host hostname. | `""` |
-| ingress.useDefault | bool | If set to true, will deploy an nginx ingress that will allow you to access Coder from an external IP address, but only if your kubernetes cluster is configured to provision external IP addresses. If you would like to bring your own ingress and hook Coder into that instead, set this value to false. | `false` |
+| ingress.useDefault | bool | If set to true, will deploy an nginx ingress that will allow you to access Coder from an external IP address, but only if your kubernetes cluster is configured to provision external IP addresses. If you would like to bring your own ingress and hook Coder into that instead, set this value to false. | `true` |
 | ingress.usePathWildcards | bool | Whether or not the ingress object should use path wildcards, i.e., ending with "/*". Some ingresses require this while others do not. You should check which path style your ingress requires. For ingress-nginx this should be set to false. | `false` |
 | logging.human | string | Where to send logs that are formatted for readability by a human. Set to an empty string to disable. | `"/dev/stderr"` |
 | logging.json | string | Where to send logs that are formatted as JSON. Set to an empty string to disable. | `""` |

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | coderd.replicas | int | The number of replicas to run of the manager. | `1` |
 | coderd.resources | object | Kubernetes resource request and limits for coderd pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
 | coderd.securityContext | object | Contains fields related to the coderd container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
-| coderd.turn | object | turn contains configuration related to running a TURN server on port 5349 NOTE: This is an alpha feature and is prone to breaking changes. | `{"enable":false}` |
-| coderd.turn.enable | bool | enables the TURN server and allows networking V2 alpha to be enabled in site config. | `false` |
 | deploymentAnnotations | object |  | `{}` |
 | devurls.host | string | Should be a wildcard hostname to allow matching against custom-created dev URLs. Leaving as an empty string results in devurls being disabled. Example: "*.devurls.coder.com". | `""` |
 | envbox.image | string | Injected during releases. | `""` |

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 
 | Key                 | Type | Description | Default                         |
 | ------------------- | ---- | ----------- | ------------------------------- |
-| cemanager.accessURL | string | The cemanager access URL that the envproxy will use to communicate with the cemanager. This should be a full URL complete with protocol and no trailing slash. Uses internal cluster URL if not set. e.g., https://manager.coder.com | `""` |
-| cemanager.image | string | Injected during releases. | `""` |
-| cemanager.replicas | int | The number of replicas to run of the manager. | `1` |
-| cemanager.resources | object | Kubernetes resource request and limits for cemanager pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
-| cemanager.securityContext | object | Contains fields related to the cemanager container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
-| cemanager.turn | object | turn contains configuration related to running a TURN server on port 5349 NOTE: This is an alpha feature and is prone to breaking changes. | `{"enable":false}` |
-| cemanager.turn.enable | bool | enables the TURN server and allows networking V2 alpha to be enabled in site config. | `false` |
 | certs | object | Describes CAs that should be added to Coder services. These certs are NOT added to environments. | `{"secret":{"key":"","name":""}}` |
 | certs.secret.key | string | The key in the secret pointing to the certificate bundle. | `""` |
 | certs.secret.name | string | The name of the secret. | `""` |
 | clusterDomainSuffix | string | If you've set a custom default domain for your cluster, you may need to remove or change this DNS suffix for service resolution to work correctly. | `".svc.cluster.local"` |
+| coderd.accessURL | string | The coderd access URL that the envproxy will use to communicate with the coderd. This should be a full URL complete with protocol and no trailing slash. Uses internal cluster URL if not set. e.g., https://manager.coder.com | `""` |
+| coderd.image | string | Injected during releases. | `""` |
+| coderd.replicas | int | The number of replicas to run of the manager. | `1` |
+| coderd.resources | object | Kubernetes resource request and limits for coderd pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
+| coderd.securityContext | object | Contains fields related to the coderd container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
+| coderd.turn | object | turn contains configuration related to running a TURN server on port 5349 NOTE: This is an alpha feature and is prone to breaking changes. | `{"enable":false}` |
+| coderd.turn.enable | bool | enables the TURN server and allows networking V2 alpha to be enabled in site config. | `false` |
 | dashboard.image | string | Injected during releases. | `""` |
 | dashboard.replicas | int | The number of replicas to run of the dashboard. | `1` |
 | dashboard.resources | object | Kubernetes resource request and limits for dashboard pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
@@ -42,8 +42,8 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | envbox.image | string | Injected during releases. | `""` |
 | environments.nodeSelector | object | nodeSelector is applied to all user environments to specify eligible nodes for environments to run on. See: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector  eg. nodeSelector:   disktype: ssd | `{}` |
 | environments.tolerations | list | Tolerations are applied to all user environments. Each element is a regular pod toleration object. To set service tolerations see serviceTolerations. See values.yaml for an example. | `[]` |
-| envproxy.accessURL | string | The URL reported to cemanager. Must be accessible by cemanager and all users who can use this workspace provider. This should be a full URL, complete with protocol and trailing "/proxy" (no trailing slash). This is derived from the ingress.host or the access URL set during cemanager setup if not set. e.g. "https://proxy.coder.com/proxy" | `""` |
-| envproxy.clusterAddress | string | The address of the K8s cluster, must be reachable from the cemanager. Defaults to "https://kubernetes.default.$clusterDomainSuffix:443" if not set. | `""` |
+| envproxy.accessURL | string | The URL reported to coderd. Must be accessible by coderd and all users who can use this workspace provider. This should be a full URL, complete with protocol and trailing "/proxy" (no trailing slash). This is derived from the ingress.host or the access URL set during coderd setup if not set. e.g. "https://proxy.coder.com/proxy" | `""` |
+| envproxy.clusterAddress | string | The address of the K8s cluster, must be reachable from the coderd. Defaults to "https://kubernetes.default.$clusterDomainSuffix:443" if not set. | `""` |
 | envproxy.image | string | Injected during releases. | `""` |
 | envproxy.replicas | int | The number of replicas to run of the envproxy. | `1` |
 | envproxy.resources | object | Kubernetes resource request and limits for envproxy pods. To unset a value, set it to "". To unset all values, you can provide a values.yaml file which sets resources to nil. See values.yaml for an example. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -21,7 +21,9 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 | Key                 | Type | Description | Default                         |
 | ------------------- | ---- | ----------- | ------------------------------- |
 {{- range .Values }}
+{{- if not (or (hasPrefix "dashboard" .Key) (hasPrefix "envproxy" .Key)) }}
 | {{ .Key }} | {{ .Type }} | {{ if .Description }}{{ .Description }}{{ else }}{{ .AutoDescription }}{{ end }} | {{ if .Default }}{{ .Default }}{{ else }}{{ .AutoDefault }}{{ end }} |
+{{- end }}
 {{- end }}
 
 ## Contributing

--- a/examples/images.yaml
+++ b/examples/images.yaml
@@ -1,5 +1,5 @@
 # Dummy image tags
-cemanager:
+coderd:
   image: gcr.io/coder/coder-service:2.0.0
 dashboard:
   image: gcr.io/coder/coder-service:2.0.0

--- a/examples/images.yaml
+++ b/examples/images.yaml
@@ -1,10 +1,6 @@
 # Dummy image tags
 coderd:
   image: gcr.io/coder/coder-service:2.0.0
-dashboard:
-  image: gcr.io/coder/coder-service:2.0.0
-envproxy:
-  image: gcr.io/coder/envproxy:2.0.0
 timescale:
   image: gcr.io/coder/timescale:2.0.0
 envbox:

--- a/examples/kind/kind.values.yaml
+++ b/examples/kind/kind.values.yaml
@@ -2,7 +2,7 @@
 ingress:
   useDefault: false
 
-cemanager:
+coderd:
   resources:
     requests:
       cpu: 100m

--- a/examples/kind/kind.values.yaml
+++ b/examples/kind/kind.values.yaml
@@ -8,18 +8,6 @@ coderd:
       cpu: 100m
       memory: 64Mi
 
-dashboard:
-  resources:
-    requests:
-      cpu: 0m
-      memory: 16Mi
-
-envproxy:
-  resources:
-    requests:
-      cpu: 0m
-      memory: 16Mi
-
 timescale:
   resources:
     requests:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -7,38 +7,29 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 {{- end }}
 
 {{- if .Values.dashboard }}
+Warning: The `dashboard` service has been deprecated.
 {{- if eq .Values.ingress.useDefault false }}
-Breaking
-{{- else -}}
-Warning
-{{- end -}}
-: The `dashboard` service will be removed in v1.21 (July 21st, 2021).
-{{- if eq .Values.ingress.useDefault false }}
-  All `dashboard` traffic must be routed to `cemanager` before v1.21.
+  All `dashboard` traffic can be routed to `cemanager`.
 {{- end }}
-  The dashboard is now served from `cemanager`. Delete `dashboard` in values.yaml.
-{{- end }}
+  Dashboard is now served from `cemanager`. Delete `dashboard` in values.yaml.
+{{ end }}
 
 {{- if .Values.envproxy }}
+Warning: The `envproxy` service has been deprecated.
 {{- if eq .Values.ingress.useDefault false }}
-Breaking
+  Coder now supports end-to-end encryption. To migrate, expose port 5349 to `cemanager`.
 {{- else }}
-Warning
-{{- end -}}
-: The `envproxy` service will be removed in v1.21 (July 21st, 2021).
-{{- if eq .Values.ingress.useDefault false }}
-  All `envproxy` traffic must be routed to `cemanager` before v1.21.
-{{- end }}
   Envproxy is now served from `cemanager`. Delete `envproxy` in values.yaml.
-{{- end }}
+{{- end}}
+{{ end }}
 
 {{- if .Values.podSecurityPolicyName }}
 Warning: `podSecurityPolicyName` is deprecated. It will be removed in v1.21 (July 21st, 2021).
 {{- end }}
 
 {{- if .Values.cemanager }}
-Breaking: The `cemanager` service will be renamed to `coderd` in v1.21 (July 21st, 2021).
+Warning: The `cemanager` service will be renamed to `coderd` in v1.21 (July 21st, 2021).
   The `cemanager` deployment, service, and ingress networking will reference `coderd`.
   If you do not reference `cemanager` externally, this change is not breaking.
   Rename `cemanager` to `coderd` in values.yaml to trigger this change.
-{{- end }}
+{{ end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -7,11 +7,29 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 {{- end }}
 
 {{- if .Values.dashboard }}
-Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021).
+{{- if eq .Values.ingress.useDefault false }}
+Breaking
+{{- else -}}
+Warning
+{{- end -}}
+: The `dashboard` service will be removed in v1.21 (July 21st, 2021).
 {{- if eq .Values.ingress.useDefault false }}
   All `dashboard` traffic must be routed to `cemanager` before v1.21.
 {{- end }}
-  Delete `dashboard` in values.yaml to migrate.
+  The dashboard is now served from `cemanager`. Delete `dashboard` in values.yaml.
+{{- end }}
+
+{{- if .Values.envproxy }}
+{{- if eq .Values.ingress.useDefault false }}
+Breaking
+{{- else }}
+Warning
+{{- end -}}
+: The `envproxy` service will be removed in v1.21 (July 21st, 2021).
+{{- if eq .Values.ingress.useDefault false }}
+  All `envproxy` traffic must be routed to `cemanager` before v1.21.
+{{- end }}
+  Envproxy is now served from `cemanager`. Delete `envproxy` in values.yaml.
 {{- end }}
 
 {{- if .Values.podSecurityPolicyName }}
@@ -21,5 +39,6 @@ Warning: `podSecurityPolicyName` is deprecated. It will be removed in v1.21 (Jul
 {{- if .Values.cemanager }}
 Breaking: The `cemanager` service will be renamed to `coderd` in v1.21 (July 21st, 2021).
   The `cemanager` deployment, service, and ingress networking will reference `coderd`.
+  If you do not reference `cemanager` externally, this change is not breaking.
   Rename `cemanager` to `coderd` in values.yaml to trigger this change.
 {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -13,3 +13,7 @@ Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021). You
 Breaking: All `dashboard` traffic should be routed to `cemanager` before v1.21.
 {{- end }}
 {{- end }}
+
+{{- if .Values.podSecurityPolicyName }}
+Warning: `podSecurityPolicyName` is deprecated. It will be removed in v1.21 (July 21st, 2021).
+{{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -19,5 +19,7 @@ Warning: `podSecurityPolicyName` is deprecated. It will be removed in v1.21 (Jul
 {{- end }}
 
 {{- if .Values.cemanager }}
-Breaking: The `cemanager` service will be renamed to `coderd` in v1.21 (July 21st, 2021). You can safely rename the `cemanager` property to `coderd`.
-{{- end}}
+Breaking: The `cemanager` service will be renamed to `coderd` in v1.21 (July 21st, 2021).
+  The `cemanager` deployment, service, and ingress networking will reference `coderd`.
+  Rename `cemanager` to `coderd` in values.yaml to trigger this change.
+{{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -7,11 +7,11 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 {{- end }}
 
 {{- if .Values.dashboard }}
-Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021). You can safely delete the `dashboard` property.
+Warning: The `dashboard` service will be removed in v1.21 (July 21st, 2021).
 {{- if eq .Values.ingress.useDefault false }}
-
-Breaking: All `dashboard` traffic should be routed to `cemanager` before v1.21.
+  All `dashboard` traffic must be routed to `cemanager` before v1.21.
 {{- end }}
+  Delete `dashboard` in values.yaml to migrate.
 {{- end }}
 
 {{- if .Values.podSecurityPolicyName }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -19,7 +19,7 @@ Warning: The `envproxy` service is deprecated since Coder v1.20, and will be rem
 {{- if eq .Values.ingress.useDefault false }}
   Coder now supports end-to-end encryption. To migrate, expose port 5349 to `cemanager`.
 {{- else }}
-  Envproxy is now served from `cemanager`. Delete `envproxy` in values.yaml.
+  The `cemanager` now bundles envproxy; delete `envproxy` in values.yaml.
 {{- end}}
 {{ end }}
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -7,7 +7,7 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 {{- end }}
 
 {{- if .Values.dashboard }}
-Warning: The `dashboard` service is deprecated since Coder v1.20, and will be removed in v1.21.
+Warning: The `dashboard` service is deprecated since Coder v1.20, and will be removed in v1.23.
 {{- if eq .Values.ingress.useDefault false }}
   All `dashboard` traffic can be routed to `cemanager`.
 {{- end }}
@@ -15,7 +15,7 @@ Warning: The `dashboard` service is deprecated since Coder v1.20, and will be re
 {{ end }}
 
 {{- if .Values.envproxy }}
-Warning: The `envproxy` service is deprecated since Coder v1.20.
+Warning: The `envproxy` service is deprecated since Coder v1.20, and will be removed in v1.23.
 {{- if eq .Values.ingress.useDefault false }}
   Coder now supports end-to-end encryption. To migrate, expose port 5349 to `cemanager`.
 {{- else }}
@@ -24,7 +24,7 @@ Warning: The `envproxy` service is deprecated since Coder v1.20.
 {{ end }}
 
 {{- if .Values.podSecurityPolicyName }}
-Warning: `podSecurityPolicyName` is deprecated since Coder v1.20.
+Warning: `podSecurityPolicyName` is deprecated since Coder v1.20, and will be removed in v1.23.
 {{- end }}
 
 {{- if .Values.cemanager }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -7,15 +7,15 @@ Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers
 {{- end }}
 
 {{- if .Values.dashboard }}
-Warning: The `dashboard` service has been deprecated.
+Warning: The `dashboard` service is deprecated since Coder v1.20, and will be removed in v1.21.
 {{- if eq .Values.ingress.useDefault false }}
   All `dashboard` traffic can be routed to `cemanager`.
 {{- end }}
-  Dashboard is now served from `cemanager`. Delete `dashboard` in values.yaml.
+  The `cemanager` serves the dashboard; delete `dashboard` in values.yaml.
 {{ end }}
 
 {{- if .Values.envproxy }}
-Warning: The `envproxy` service has been deprecated.
+Warning: The `envproxy` service is deprecated since Coder v1.20.
 {{- if eq .Values.ingress.useDefault false }}
   Coder now supports end-to-end encryption. To migrate, expose port 5349 to `cemanager`.
 {{- else }}
@@ -24,7 +24,7 @@ Warning: The `envproxy` service has been deprecated.
 {{ end }}
 
 {{- if .Values.podSecurityPolicyName }}
-Warning: `podSecurityPolicyName` is deprecated. It will be removed in v1.21 (July 21st, 2021).
+Warning: `podSecurityPolicyName` is deprecated since Coder v1.20.
 {{- end }}
 
 {{- if .Values.cemanager }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -17,3 +17,7 @@ Breaking: All `dashboard` traffic should be routed to `cemanager` before v1.21.
 {{- if .Values.podSecurityPolicyName }}
 Warning: `podSecurityPolicyName` is deprecated. It will be removed in v1.21 (July 21st, 2021).
 {{- end }}
+
+{{- if .Values.cemanager }}
+Breaking: The `cemanager` service will be renamed to `coderd` in v1.21 (July 21st, 2021). You can safely rename the `cemanager` property to `coderd`.
+{{- end}}

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -82,17 +82,17 @@ tolerations:
   coder.accessURL is a URL for accessing the coderd.
 */}}
 {{- define "coder.accessURL" }}
-{{- if hasKey .Values "coderd" }}
+{{- if hasKey .Values "cemanager" }}
+{{- if ne .Values.cemanager.accessURL "" }}
+{{- .Values.coderd.accessURL -}}
+{{- else -}}
+    http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
+{{- end }}
+{{- else -}}
 {{- if ne .Values.coderd.accessURL "" }}
 {{- .Values.coderd.accessURL -}}
 {{- else -}}
     http://coderd.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
-{{- end }}
-{{- else -}}
-{{- if ne .Values.cemanager.accessURL "" }}
-{{- .Values.cemanager.accessURL -}}
-{{- else -}}
-    http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -135,7 +135,9 @@ nodeSelector:
 {{- end }}
 
 {{- define "coder.serviceName" }}
-{{- if hasKey .Values "cemanager" }}cemanagerasdasd
-{{- else -}}coderd
+{{- if hasKey .Values "cemanager" -}}
+cemanager
+{{- else -}}
+coderd
 {{- end }}
 {{- end }}

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -83,13 +83,13 @@ tolerations:
 */}}
 {{- define "coder.accessURL" }}
 {{- if hasKey .Values "coderd" }}
-{{- if ne (default .Values.coderd.accessURL) "" }}
+{{- if ne .Values.coderd.accessURL "" }}
 {{- .Values.coderd.accessURL -}}
 {{- else -}}
     http://coderd.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
 {{- end }}
 {{- else -}}
-{{- if ne (default .Values.cemanager.accessURL) "" }}
+{{- if ne .Values.cemanager.accessURL "" }}
 {{- .Values.cemanager.accessURL -}}
 {{- else -}}
     http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -79,13 +79,21 @@ tolerations:
 {{- end }}
 {{- end }}
 {{/*
-  coder.coderd.accessURL is a URL for accessing the coderd.
+  coder.accessURL is a URL for accessing the coderd.
 */}}
-{{- define "coder.coderd.accessURL" }}
-{{- if ne (default .Values.cemanager.accessURL .Values.coderd.accessURL) "" }}
-{{- default .Values.cemanager.accessURL .Values.coderd.accessURL -}}
+{{- define "coder.accessURL" }}
+{{- if hasKey .Values "coderd" }}
+{{- if ne (default .Values.coderd.accessURL) "" }}
+{{- .Values.coderd.accessURL -}}
 {{- else -}}
     http://coderd.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
+{{- end }}
+{{- else -}}
+{{- if ne (default .Values.cemanager.accessURL) "" }}
+{{- .Values.cemanager.accessURL -}}
+{{- else -}}
+    http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
+{{- end }}
 {{- end }}
 {{- end }}
 {{/*
@@ -123,5 +131,11 @@ tolerations:
 {{- if .Values.services.nodeSelector }}
 nodeSelector:
 {{ toYaml .Values.services.nodeSelector | indent 1 }}
+{{- end }}
+{{- end }}
+
+{{- define "coder.serviceName" }}
+{{- if hasKey .Values "cemanager" }}cemanagerasdasd
+{{- else -}}coderd
 {{- end }}
 {{- end }}

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -79,13 +79,13 @@ tolerations:
 {{- end }}
 {{- end }}
 {{/*
-  coder.cemanager.accessURL is a URL for accessing the cemanager.
+  coder.coderd.accessURL is a URL for accessing the coderd.
 */}}
-{{- define "coder.cemanager.accessURL" }}
-{{- if ne .Values.cemanager.accessURL "" }}
-{{- .Values.cemanager.accessURL -}}
+{{- define "coder.coderd.accessURL" }}
+{{- if ne (default .Values.cemanager.accessURL .Values.coderd.accessURL) "" }}
+{{- default .Values.cemanager.accessURL .Values.coderd.accessURL -}}
 {{- else -}}
-    http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
+    http://coderd.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix }}:8080
 {{- end }}
 {{- end }}
 {{/*

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -92,7 +92,7 @@ spec:
               echo Starting entrypoint.sh;
               exec /entrypoint.sh coderd migrate up
       containers:
-        - name: {{ include "coder.serviceName" . | quote }}
+        - name: {{ include "coder.serviceName" . }}
           {{- if hasKey .Values "cemanager" }}
           image: {{ .Values.cemanager.image | quote }}
           {{- else }}
@@ -145,9 +145,9 @@ spec:
               value: {{ .Values.storageClassName | quote }}
             - name: TURN_ENABLED
               {{- if hasKey .Values "cemanager" }}
-              value: {{ .Values.cemanager.turn.enable }}
+              value: {{ .Values.cemanager.turn.enable | quote }}
               {{- else }}
-              value: {{ .Values.coderd.turn.enable }}
+              value: {{ .Values.coderd.turn.enable | quote }}
               {{- end }}
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -102,6 +102,8 @@ spec:
           ports:
             - name: tcp-{{ include "coder.serviceName" . }}
               containerPort: 8080
+            - name: tcp-turns-{{ include "coder.serviceName" . }}
+              containerPort: 5349
           securityContext:
             allowPrivilegeEscalation: false
             {{- if hasKey .Values "cemanager" }}

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -11,26 +11,30 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    coder.deployment: coderd
-  name: coderd
+    coder.deployment: {{ include "coder.serviceName" . }}
+  name: {{ include "coder.serviceName" . }}
   namespace: {{ .Release.Namespace | quote }}
   annotations:
   {{- range $key, $value := .Values.deploymentAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  replicas: {{ default .Values.cemanager.replicas .Values.coderd.replicas }}
+  {{- if hasKey .Values "cemanager" }}
+  replicas: {{ .Values.cemanager.replicas }}
+  {{- else -}}
+  replicas: {{ .Values.coderd.replicas }}
+  {{- end }}
   strategy:
     rollingUpdate:
       maxSurge: "25%"
       maxUnavailable: "25%"
   selector:
     matchLabels:
-      coder.deployment: coderd
+      coder.deployment: {{ include "coder.serviceName" . }}
   template:
     metadata:
       labels:
-        coder.deployment: coderd
+        coder.deployment: {{ include "coder.serviceName" . }}
       annotations:
       {{- range $key, $value := .Values.deploymentAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -50,7 +54,11 @@ spec:
 {{- include "coder.serviceTolerations" . | indent 6 }}
       initContainers:
         - name: migrations
-          image: {{ default .Values.cemanager.image .Values.coderd.image | quote }}
+          {{- if hasKey .Values "cemanager" }}
+          image: {{ .Values.cemanager.image | quote }}
+          {{- else -}}
+          image: {{ .Values.coderd.image | quote }}
+          {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           env:
             - name: HUMAN_LOG
@@ -84,15 +92,23 @@ spec:
               echo Starting entrypoint.sh;
               exec /entrypoint.sh coderd migrate up
       containers:
-        - name: coderd
-          image: {{ default .Values.cemanager.image .Values.coderd.image | quote }}
+        - name: {{ include "coder.serviceName" . | quote }}
+          {{- if hasKey .Values "cemanager" }}
+          image: {{ .Values.cemanager.image | quote }}
+          {{- else -}}
+          image: {{ .Values.coderd.image | quote }}
+          {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           ports:
-            - name: tcp-cemanager
+            - name: tcp-{{ include "coder.serviceName" . }}
               containerPort: 8080
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: {{ default .Values.cemanager.securityContext.readOnlyRootFilesystem .Values.coderd.securityContext.readOnlyRootFilesystem }}
+            {{- if hasKey .Values "cemanager" }}
+            readOnlyRootFilesystem: {{ .Values.cemanager.securityContext.readOnlyRootFilesystem }}
+            {{- else -}}
+            readOnlyRootFilesystem: {{ .Values.coderd.securityContext.readOnlyRootFilesystem }}
+            {{- end }}
           # coderd is a daemon service, no need to allocate a tty for it.
           tty: false
           env:
@@ -128,7 +144,11 @@ spec:
             - name: STORAGE_CLASS
               value: {{ .Values.storageClassName | quote }}
             - name: TURN_ENABLED
-              value: {{ default .Values.cemanager.turn.enable .Values.coderd.turn.enable | quote }}
+              {{- if hasKey .Values "cemanager" }}
+              value: {{ .Values.cemanager.turn.enable }}
+              {{- else -}}
+              value: {{ .Values.coderd.turn.enable }}
+              {{- end }}
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}
           command:
@@ -155,8 +175,13 @@ spec:
             initialDelaySeconds: 10
             failureThreshold: 7
             periodSeconds: 10
-{{- include "coder.resources" .Values.cemanager.resources | default .Values.coderd.resources | indent 10 }}
-{{- if and (default .Values.cemanager.turn.enable .Values.coderd.turn.enable) .Values.ingress.tls.enable }}
+{{- if hasKey .Values "cemanager" }}
+{{- include "coder.resources" .Values.cemanager.resources | indent 10 }}
+{{- else -}}
+{{- include "coder.resources" .Values.coderd.resources | indent 10 }}
+{{- end }}
+{{- if hasKey .Values "cemanager" }}
+{{- if and .Values.cemanager.turn.enable .Values.ingress.tls.enable }}
           volumeMounts:
             - mountPath: /etc/coder/certificates
               name: tls
@@ -166,23 +191,35 @@ spec:
           secret:
             secretName: {{ .Values.ingress.tls.hostSecretName | quote }}
 {{- end }}
+{{- else -}}
+{{- if and .Values.coderd.turn.enable .Values.ingress.tls.enable }}
+          volumeMounts:
+            - mountPath: /etc/coder/certificates
+              name: tls
+              readOnly: true
+      volumes:
+        - name: tls
+          secret:
+            secretName: {{ .Values.ingress.tls.hostSecretName | quote }}
+{{- end }}
+{{- end}}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: coderd
+  name: {{ include "coder.serviceName" . }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.serviceType | quote}}
   selector:
-    coder.deployment: coderd
+    coder.deployment: {{ include "coder.serviceName" . }}
   ports:
-    - name: tcp-coderd
+    - name: tcp-{{ include "coder.serviceName" . }}
       port: 8080
       protocol: TCP
-    - name: tcp-coderd-https
+    - name: tcp-{{ include "coder.serviceName" . }}-https
       port: 8443
       protocol: TCP
-    - name: tcp-coderd-turns
+    - name: tcp-{{ include "coder.serviceName" . }}-turns
       port: 5349
       protocol: TCP

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -144,11 +144,7 @@ spec:
             - name: STORAGE_CLASS
               value: {{ .Values.storageClassName | quote }}
             - name: TURN_ENABLED
-              {{- if hasKey .Values "cemanager" }}
-              value: {{ .Values.cemanager.turn.enable | quote }}
-              {{- else }}
-              value: {{ .Values.coderd.turn.enable | quote }}
-              {{- end }}
+              value: "true"
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}
           command:
@@ -180,8 +176,6 @@ spec:
 {{- else }}
 {{- include "coder.resources" .Values.coderd.resources | indent 10 }}
 {{- end }}
-{{- if hasKey .Values "cemanager" }}
-{{- if and .Values.cemanager.turn.enable .Values.ingress.tls.enable }}
           volumeMounts:
             - mountPath: /etc/coder/certificates
               name: tls
@@ -190,19 +184,6 @@ spec:
         - name: tls
           secret:
             secretName: {{ .Values.ingress.tls.hostSecretName | quote }}
-{{- end }}
-{{- else }}
-{{- if and .Values.coderd.turn.enable .Values.ingress.tls.enable }}
-          volumeMounts:
-            - mountPath: /etc/coder/certificates
-              name: tls
-              readOnly: true
-      volumes:
-        - name: tls
-          secret:
-            secretName: {{ .Values.ingress.tls.hostSecretName | quote }}
-{{- end }}
-{{- end}}
 ---
 apiVersion: v1
 kind: Service

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -11,26 +11,26 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    coder.deployment: cemanager
-  name: cemanager
+    coder.deployment: coderd
+  name: coderd
   namespace: {{ .Release.Namespace | quote }}
   annotations:
   {{- range $key, $value := .Values.deploymentAnnotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cemanager.replicas }}
+  replicas: {{ default .Values.cemanager.replicas .Values.coderd.replicas }}
   strategy:
     rollingUpdate:
       maxSurge: "25%"
       maxUnavailable: "25%"
   selector:
     matchLabels:
-      coder.deployment: cemanager
+      coder.deployment: coderd
   template:
     metadata:
       labels:
-        coder.deployment: cemanager
+        coder.deployment: coderd
       annotations:
       {{- range $key, $value := .Values.deploymentAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -50,7 +50,7 @@ spec:
 {{- include "coder.serviceTolerations" . | indent 6 }}
       initContainers:
         - name: migrations
-          image: {{ .Values.cemanager.image | quote }}
+          image: {{ default .Values.cemanager.image .Values.coderd.image | quote }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           env:
             - name: HUMAN_LOG
@@ -82,18 +82,18 @@ spec:
               echo Waiting on db;
               /wait_postgres.sh --host="$DB_HOST" --port="$DB_PORT" -U "$DB_USER";
               echo Starting entrypoint.sh;
-              exec /entrypoint.sh cemanager migrate up
+              exec /entrypoint.sh coderd migrate up
       containers:
-        - name: cemanager
-          image: {{ .Values.cemanager.image | quote }}
+        - name: coderd
+          image: {{ default .Values.cemanager.image .Values.coderd.image | quote }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           ports:
             - name: tcp-cemanager
               containerPort: 8080
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: {{ .Values.cemanager.securityContext.readOnlyRootFilesystem }}
-          # cemanager is a daemon service, no need to allocate a tty for it.
+            readOnlyRootFilesystem: {{ default .Values.cemanager.securityContext.readOnlyRootFilesystem .Values.coderd.securityContext.readOnlyRootFilesystem }}
+          # coderd is a daemon service, no need to allocate a tty for it.
           tty: false
           env:
             - name: SKIP_MIGRATIONS
@@ -128,7 +128,7 @@ spec:
             - name: STORAGE_CLASS
               value: {{ .Values.storageClassName | quote }}
             - name: TURN_ENABLED
-              value: {{ .Values.cemanager.turn.enable | quote }}
+              value: {{ default .Values.cemanager.turn.enable .Values.coderd.turn.enable | quote }}
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}
           command:
@@ -140,7 +140,7 @@ spec:
               PGSSLMODE="${DB_SSL_MODE:-prefer}" /wait_postgres.sh --host="$DB_HOST" --port="$DB_PORT" -U "$DB_USER";
               echo Starting entrypoint.sh;
               # Pass signals down to the envmanager.
-              exec /entrypoint.sh cemanager run
+              exec /entrypoint.sh coderd run
           readinessProbe:
             httpGet:
               path: /cem-healthz
@@ -155,8 +155,8 @@ spec:
             initialDelaySeconds: 10
             failureThreshold: 7
             periodSeconds: 10
-{{- include "coder.resources" .Values.cemanager.resources | indent 10 }}
-{{- if and .Values.cemanager.turn.enable .Values.ingress.tls.enable }}
+{{- include "coder.resources" .Values.cemanager.resources | default .Values.coderd.resources | indent 10 }}
+{{- if and (default .Values.cemanager.turn.enable .Values.coderd.turn.enable) .Values.ingress.tls.enable }}
           volumeMounts:
             - mountPath: /etc/coder/certificates
               name: tls
@@ -170,19 +170,19 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: cemanager
+  name: coderd
   namespace: {{ .Release.Namespace | quote }}
 spec:
   type: {{ .Values.serviceType | quote}}
   selector:
-    coder.deployment: cemanager
+    coder.deployment: coderd
   ports:
-    - name: tcp-cemanager
+    - name: tcp-coderd
       port: 8080
       protocol: TCP
-    - name: tcp-cemanager-https
+    - name: tcp-coderd-https
       port: 8443
       protocol: TCP
-    - name: tcp-cemanager-turns
+    - name: tcp-coderd-turns
       port: 5349
       protocol: TCP

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   {{- if hasKey .Values "cemanager" }}
   replicas: {{ .Values.cemanager.replicas }}
-  {{- else -}}
+  {{- else }}
   replicas: {{ .Values.coderd.replicas }}
   {{- end }}
   strategy:
@@ -56,7 +56,7 @@ spec:
         - name: migrations
           {{- if hasKey .Values "cemanager" }}
           image: {{ .Values.cemanager.image | quote }}
-          {{- else -}}
+          {{- else }}
           image: {{ .Values.coderd.image | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
@@ -95,7 +95,7 @@ spec:
         - name: {{ include "coder.serviceName" . | quote }}
           {{- if hasKey .Values "cemanager" }}
           image: {{ .Values.cemanager.image | quote }}
-          {{- else -}}
+          {{- else }}
           image: {{ .Values.coderd.image | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
@@ -106,7 +106,7 @@ spec:
             allowPrivilegeEscalation: false
             {{- if hasKey .Values "cemanager" }}
             readOnlyRootFilesystem: {{ .Values.cemanager.securityContext.readOnlyRootFilesystem }}
-            {{- else -}}
+            {{- else }}
             readOnlyRootFilesystem: {{ .Values.coderd.securityContext.readOnlyRootFilesystem }}
             {{- end }}
           # coderd is a daemon service, no need to allocate a tty for it.
@@ -146,7 +146,7 @@ spec:
             - name: TURN_ENABLED
               {{- if hasKey .Values "cemanager" }}
               value: {{ .Values.cemanager.turn.enable }}
-              {{- else -}}
+              {{- else }}
               value: {{ .Values.coderd.turn.enable }}
               {{- end }}
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
@@ -177,7 +177,7 @@ spec:
             periodSeconds: 10
 {{- if hasKey .Values "cemanager" }}
 {{- include "coder.resources" .Values.cemanager.resources | indent 10 }}
-{{- else -}}
+{{- else }}
 {{- include "coder.resources" .Values.coderd.resources | indent 10 }}
 {{- end }}
 {{- if hasKey .Values "cemanager" }}
@@ -191,7 +191,7 @@ spec:
           secret:
             secretName: {{ .Values.ingress.tls.hostSecretName | quote }}
 {{- end }}
-{{- else -}}
+{{- else }}
 {{- if and .Values.coderd.turn.enable .Values.ingress.tls.enable }}
           volumeMounts:
             - mountPath: /etc/coder/certificates

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -39,7 +39,7 @@ spec:
 {{- include "coder.serviceTolerations" . | indent 6 }}
       containers:
         - name: dashboard
-          image: {{ .Values.cemanager.image | quote }}
+          image: {{ default .Values.cemanager.image .Values.coderd.image | quote }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           ports:
             - name: tcp-dashboard
@@ -50,13 +50,13 @@ spec:
           # dashboard runs a node server. no tty is needed for it.
           tty: false
           env:
-            - name: CEMANAGER_HOST
-              value: "http://cemanager.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix}}:8080"
+            - name: CODERD_HOST
+              value: "http://coderd.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix}}:8080"
           command:
             - /bin/bash
             - -c
             - |
-              exec cemanager replica --bind 0.0.0.0:3000 --main-url $CEMANAGER_HOST 
+              exec coderd replica --bind 0.0.0.0:3000 --main-url $CODERD_HOST 
           readinessProbe:
             httpGet:
               path: /healthz

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -1,5 +1,4 @@
 # Optionally include the dashboard if it's specified.
-# The dashboard will be removed in v1.21.
 {{- if hasKey .Values "dashboard" }}
 ---
 apiVersion: apps/v1

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -1,3 +1,6 @@
+# Optionally include the dashboard if it's specified.
+# The dashboard will be removed in v1.21.
+{{- if hasKey .Values "dashboard" }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -96,3 +99,4 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace | quote }}
   name: dashboard
+{{- end }}

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -41,7 +41,7 @@ spec:
         - name: dashboard
           {{- if hasKey .Values "cemanager" }}
           image: {{ .Values.cemanager.image | quote }}
-          {{- else -}}
+          {{- else }}
           image: {{ .Values.coderd.image | quote }}
           {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -39,7 +39,11 @@ spec:
 {{- include "coder.serviceTolerations" . | indent 6 }}
       containers:
         - name: dashboard
-          image: {{ default .Values.cemanager.image .Values.coderd.image | quote }}
+          {{- if hasKey .Values "cemanager" }}
+          image: {{ .Values.cemanager.image | quote }}
+          {{- else -}}
+          image: {{ .Values.coderd.image | quote }}
+          {{- end }}
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           ports:
             - name: tcp-dashboard
@@ -51,7 +55,7 @@ spec:
           tty: false
           env:
             - name: CODERD_HOST
-              value: "http://coderd.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix}}:8080"
+              value: "http://{{ include "coder.serviceName" . }}.{{ .Release.Namespace }}{{ .Values.clusterDomainSuffix}}:8080"
           command:
             - /bin/bash
             - -c

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -1,3 +1,5 @@
+# Envproxy is being removed in v1.21.
+{{- if hasKey .Values "envproxy" }}
 ---
 apiVersion: v1
 kind: Secret
@@ -153,4 +155,5 @@ spec:
     - name: tcp-ssh
       port: 2222
       protocol: TCP
+{{- end }}
 {{- end }}

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -101,7 +101,7 @@ spec:
             - name: SSH_ENABLED
               value: {{ .Values.ssh.enable | quote }}
             - name: CEMANAGER_ACCESS_URL
-              value: {{ include "coder.cemanager.accessURL" . | quote }}
+              value: {{ include "coder.coderd.accessURL" . | quote }}
             - name: CEMANAGER_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -101,7 +101,7 @@ spec:
             - name: SSH_ENABLED
               value: {{ .Values.ssh.enable | quote }}
             - name: CEMANAGER_ACCESS_URL
-              value: {{ include "coder.coderd.accessURL" . | quote }}
+              value: {{ include "coder.accessURL" . | quote }}
             - name: CEMANAGER_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -389,10 +389,12 @@ spec:
     http:
       paths:
     {{- if or (not .Values.ingress.usePathWildcards) .Values.ingress.useDefault }}
+      {{- if hasKey .Values "envproxy" }}
       - path: /proxy/
         backend:
           serviceName: envproxy
           servicePort: 8080
+      {{- end }}
       - path: /api/
         backend:
           serviceName: {{ include "coder.serviceName" . }}
@@ -403,16 +405,26 @@ spec:
           servicePort: 8080
       - path: /
         backend:
+          {{- if hasKey .Values "dashboard" }}
           serviceName: dashboard
           servicePort: 3000
+          {{- else }}
+          serviceName: {{ include "coder.serviceName" . }}
+          servicePort: 8080
+          {{- end }}
     {{- if ne .Values.devurls.host "" }}
   - host: {{ .Values.devurls.host | quote }}
     http:
       paths:
       - path: /
         backend:
+          {{- if hasKey .Values "envproxy" }}
           serviceName: envproxy
           servicePort: 8080
+          {{- else }}
+          serviceName: {{ include "coder.serviceName" . }}
+          servicePort: 8080
+          {{- end }}
     {{- end }}
     {{- else }}
       - path: /proxy/*
@@ -429,16 +441,26 @@ spec:
           servicePort: 8080
       - path: /*
         backend:
+          {{- if hasKey .Values "dashboard" }}
           serviceName: dashboard
           servicePort: 3000
+          {{- else }}
+          serviceName: {{ include "coder.serviceName" . }}
+          servicePort: 8080
+          {{- end }}
     {{- if ne .Values.devurls.host "" }}
   - host: {{ .Values.devurls.host | quote }}
     http:
       paths:
       - path: /*
         backend:
+          {{- if hasKey .Values "envproxy" }}
           serviceName: envproxy
           servicePort: 8080
+          {{- else }}
+          serviceName: {{ include "coder.serviceName" . }}
+          servicePort: 8080
+          {{- end }}
     {{- end }}
     {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 data:
   22: "{{ .Release.Namespace }}/envproxy:2222"
-  5349: "{{ .Release.Namespace }}/coderd:5349"
+  5349: "{{ .Release.Namespace }}/{{ include "coder.serviceName" . }}:5349"
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -339,10 +339,19 @@ spec:
       targetPort: 22
       protocol: TCP
 {{- end }}
+{{- if hasKey .Values "cemanager" }}
 {{- if .Values.cemanager.turn.enable }}
     - name: turns
       port: 5349
       targetPort: 5349
+{{- end }}
+{{- end }}
+{{- if hasKey .Values "coderd" }}
+{{- if .Values.coderd.turn.enable }}
+    - name: turns
+      port: 5349
+      targetPort: 5349
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if or .Values.ingress.useDefault .Values.ingress.enable }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -339,20 +339,9 @@ spec:
       targetPort: 22
       protocol: TCP
 {{- end }}
-{{- if hasKey .Values "cemanager" }}
-{{- if .Values.cemanager.turn.enable }}
     - name: turns
       port: 5349
       targetPort: 5349
-{{- end }}
-{{- end }}
-{{- if hasKey .Values "coderd" }}
-{{- if .Values.coderd.turn.enable }}
-    - name: turns
-      port: 5349
-      targetPort: 5349
-{{- end }}
-{{- end }}
 {{- end }}
 {{- if or .Values.ingress.useDefault .Values.ingress.enable }}
 ---

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/part-of: ingress-nginx
 data:
   22: "{{ .Release.Namespace }}/envproxy:2222"
-  5349: "{{ .Release.Namespace }}/cemanager:5349"
+  5349: "{{ .Release.Namespace }}/coderd:5349"
 ---
 kind: ConfigMap
 apiVersion: v1
@@ -339,7 +339,7 @@ spec:
       targetPort: 22
       protocol: TCP
 {{- end }}
-{{- if .Values.cemanager.turn.enable }}
+{{- if .Values.coderd.turn.enable }}
     - name: turns
       port: 5349
       targetPort: 5349

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -339,7 +339,7 @@ spec:
       targetPort: 22
       protocol: TCP
 {{- end }}
-{{- if .Values.coderd.turn.enable }}
+{{- if .Values.cemanager.turn.enable }}
     - name: turns
       port: 5349
       targetPort: 5349
@@ -373,7 +373,7 @@ metadata:
 spec:
 {{- include "coder.ingress.tls" . }}
   backend:
-    serviceName: cemanager
+    serviceName: {{ include "coder.serviceName" . }}
     servicePort: 8080
   rules:
   - host: {{ .Values.ingress.host | quote }}
@@ -386,11 +386,11 @@ spec:
           servicePort: 8080
       - path: /api/
         backend:
-          serviceName: cemanager
+          serviceName: {{ include "coder.serviceName" . }}
           servicePort: 8080
       - path: /auth/
         backend:
-          serviceName: cemanager
+          serviceName: {{ include "coder.serviceName" . }}
           servicePort: 8080
       - path: /
         backend:
@@ -412,11 +412,11 @@ spec:
           servicePort: 8080
       - path: /api/*
         backend:
-          serviceName: cemanager
+          serviceName: {{ include "coder.serviceName" . }}
           servicePort: 8080
       - path: /auth/*
         backend:
-          serviceName: cemanager
+          serviceName: {{ include "coder.serviceName" . }}
           servicePort: 8080
       - path: /*
         backend:

--- a/templates/psp.yaml
+++ b/templates/psp.yaml
@@ -27,7 +27,7 @@ subjects:
     name: timescale
     namespace: {{ .Release.Namespace | quote }}
   - kind: ServiceAccount
-    name: cemanager
+    name: coderd
     namespace: {{ .Release.Namespace | quote }}
   - kind: ServiceAccount
     name: envproxy

--- a/templates/psp.yaml
+++ b/templates/psp.yaml
@@ -27,7 +27,7 @@ subjects:
     name: timescale
     namespace: {{ .Release.Namespace | quote }}
   - kind: ServiceAccount
-    name: coderd
+    name: {{ include "coder.serviceName" }}
     namespace: {{ .Release.Namespace | quote }}
   - kind: ServiceAccount
     name: envproxy

--- a/values.yaml
+++ b/values.yaml
@@ -169,7 +169,7 @@ coderd:
       cpu: "250m"
       memory: "512Mi"
 
-# Deprecated: Being removed in v1.21.
+# `dashboard` is deprecated as of v1.20.
 # Contains the user interface of the platform.
 dashboard:
   # dashboard.replicas -- The number of replicas to run of the dashboard.
@@ -202,7 +202,7 @@ dashboard:
       cpu: "250m"
       memory: "512Mi"
 
-# Deprecated: Being removed in v1.21.
+# `envproxy` is deprecated as of v1.20.
 # envproxy contains configuration for the service handling long-lived
 # connections to environments such as IDE or shell sessions.
 envproxy:

--- a/values.yaml
+++ b/values.yaml
@@ -133,31 +133,31 @@ imagePullPolicy: Always
 
 # Contains configuration the REST API handling CRUD operations to
 # the platform.
-cemanager:
-  # cemanager.accessURL -- The cemanager access URL that the envproxy will use
-  # to communicate with the cemanager. This should be a full URL complete with
+coderd:
+  # coderd.accessURL -- The coderd access URL that the envproxy will use
+  # to communicate with the coderd. This should be a full URL complete with
   # protocol and no trailing slash. Uses internal cluster URL if not set.
   # e.g., https://manager.coder.com
   accessURL: ""
-  # cemanager.replicas -- The number of replicas to run of the manager.
+  # coderd.replicas -- The number of replicas to run of the manager.
   replicas: 1
-  # cemanager.image -- Injected during releases.
+  # coderd.image -- Injected during releases.
   image: ""
-  # cemanager.securityContext -- Contains fields related to the cemanager
+  # coderd.securityContext -- Contains fields related to the coderd
   # container's security context (as opposed to the pod).
   securityContext:
-    # cemanager.securityContext.readonlyRootFilesystem -- Sets the root filesystem
-    # of the cemanager container to read-only. It is recommended to leave this setting enabled
+    # coderd.securityContext.readonlyRootFilesystem -- Sets the root filesystem
+    # of the coderd container to read-only. It is recommended to leave this setting enabled
     # in production.
     readOnlyRootFilesystem: true
-  # cemanager.resources -- Kubernetes resource request and limits for cemanager
+  # coderd.resources -- Kubernetes resource request and limits for coderd
   # pods.
   # To unset a value, set it to "".
   # To unset all values, you can provide a values.yaml file which sets resources
   # to nil. See values.yaml for an example.
   #
   # e.g:
-  # cemanager:
+  # coderd:
   #   # This will cause all values to be unset.
   #   resources:
   #   replica: 1
@@ -168,10 +168,10 @@ cemanager:
     limits:
       cpu: "250m"
       memory: "512Mi"
-  # cemanager.turn -- turn contains configuration related to running a TURN server on port 5349
+  # coderd.turn -- turn contains configuration related to running a TURN server on port 5349
   # NOTE: This is an alpha feature and is prone to breaking changes.
   turn:
-    # cemanager.turn.enable -- enables the TURN server and allows networking V2 alpha to be enabled in site config.
+    # coderd.turn.enable -- enables the TURN server and allows networking V2 alpha to be enabled in site config.
     enable: false
 
 # Contains the user interface of the platform.
@@ -209,15 +209,15 @@ dashboard:
 # envproxy contains configuration for the service handling long-lived
 # connections to environments such as IDE or shell sessions.
 envproxy:
-  # envproxy.accessURL -- The URL reported to cemanager. Must be accessible by
-  # cemanager and all users who can use this workspace provider. This should be
+  # envproxy.accessURL -- The URL reported to coderd. Must be accessible by
+  # coderd and all users who can use this workspace provider. This should be
   # a full URL, complete with protocol and trailing "/proxy" (no trailing
   # slash). This is derived from the ingress.host or the access URL set during
-  # cemanager setup if not set.
+  # coderd setup if not set.
   # e.g. "https://proxy.coder.com/proxy"
   accessURL: ""
   # envproxy.clusterAddress -- The address of the K8s cluster, must be reachable
-  # from the cemanager. Defaults to
+  # from the coderd. Defaults to
   # "https://kubernetes.default.$clusterDomainSuffix:443" if not set.
   clusterAddress: ""
   # envproxy.replicas -- The number of replicas to run of the envproxy.

--- a/values.yaml
+++ b/values.yaml
@@ -133,7 +133,7 @@ imagePullPolicy: Always
 
 # Contains configuration the REST API handling CRUD operations to
 # the platform.
-coderd:
+cemanager:
   # coderd.accessURL -- The coderd access URL that the envproxy will use
   # to communicate with the coderd. This should be a full URL complete with
   # protocol and no trailing slash. Uses internal cluster URL if not set.

--- a/values.yaml
+++ b/values.yaml
@@ -174,6 +174,7 @@ coderd:
     # coderd.turn.enable -- enables the TURN server and allows networking V2 alpha to be enabled in site config.
     enable: false
 
+# Deprecated: Being removed in v1.21.
 # Contains the user interface of the platform.
 dashboard:
   # dashboard.replicas -- The number of replicas to run of the dashboard.
@@ -206,6 +207,7 @@ dashboard:
       cpu: "250m"
       memory: "512Mi"
 
+# Deprecated: Being removed in v1.21.
 # envproxy contains configuration for the service handling long-lived
 # connections to environments such as IDE or shell sessions.
 envproxy:

--- a/values.yaml
+++ b/values.yaml
@@ -133,7 +133,7 @@ imagePullPolicy: Always
 
 # Contains configuration the REST API handling CRUD operations to
 # the platform.
-cemanager:
+coderd:
   # coderd.accessURL -- The coderd access URL that the envproxy will use
   # to communicate with the coderd. This should be a full URL complete with
   # protocol and no trailing slash. Uses internal cluster URL if not set.

--- a/values.yaml
+++ b/values.yaml
@@ -168,11 +168,6 @@ coderd:
     limits:
       cpu: "250m"
       memory: "512Mi"
-  # coderd.turn -- turn contains configuration related to running a TURN server on port 5349
-  # NOTE: This is an alpha feature and is prone to breaking changes.
-  turn:
-    # coderd.turn.enable -- enables the TURN server and allows networking V2 alpha to be enabled in site config.
-    enable: false
 
 # Deprecated: Being removed in v1.21.
 # Contains the user interface of the platform.


### PR DESCRIPTION
Enables migration from `cemanager` to `coderd` in values.yaml.

Deployments will output a deprecation notice to update the value.

Output when updating to 1.20 with built-in ingress:
![image](https://user-images.githubusercontent.com/7122116/119393317-61fcb600-bc96-11eb-9d7e-929fc211c0c2.png)

Output when updating to 1.20 with custom ingress:
![image](https://user-images.githubusercontent.com/7122116/119393258-54dfc700-bc96-11eb-98bd-5e897c07ee61.png)

Allows customers to remove envproxy and the dashboard in 1.20, without a forced removal.