### PR TITLE
fix: Remove deprecation notices until v1.21

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,30 +6,6 @@ Warning: `ingress.additionalAnnotations` has been moved to `ingress.annotations`
 Warning: `namespaceWhitelist` has been removed. Use multiple workspace providers instead. See: https://coder.com/docs/admin/workspace-providers
 {{- end }}
 
-{{- if .Values.dashboard }}
-Warning: The `dashboard` service is deprecated since Coder v1.20, and will be removed in v1.23.
-{{- if eq .Values.ingress.useDefault false }}
-  All `dashboard` traffic can be routed to `cemanager`.
-{{- end }}
-  The `cemanager` serves the dashboard; delete `dashboard` in values.yaml.
-{{ end }}
-
-{{- if .Values.envproxy }}
-Warning: The `envproxy` service is deprecated since Coder v1.20, and will be removed in v1.23.
-{{- if eq .Values.ingress.useDefault false }}
-  Coder now supports end-to-end encryption. To migrate, expose port 5349 to `cemanager`.
-{{- else }}
-  The `cemanager` now bundles envproxy; delete `envproxy` in values.yaml.
-{{- end}}
-{{ end }}
-
 {{- if .Values.podSecurityPolicyName }}
 Warning: `podSecurityPolicyName` is deprecated since Coder v1.20, and will be removed in v1.23.
 {{- end }}
-
-{{- if .Values.cemanager }}
-Warning: The `cemanager` service will be renamed to `coderd` in v1.21 (July 21st, 2021).
-  The `cemanager` deployment, service, and ingress networking will reference `coderd`.
-  If you do not reference `cemanager` externally, this change is not breaking.
-  Rename `cemanager` to `coderd` in values.yaml to trigger this change.
-{{ end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -321,7 +321,7 @@ spec:
   loadBalancerIP: {{ .Values.ingress.loadBalancerIP | quote }}
   {{- if ne (len .Values.ingress.loadBalancerSourceRanges) 0 }}
   loadBalancerSourceRanges:
-    {{ toYaml .Values.ingress.loadBalancerSourceRanges | indent 4 }}
+{{ toYaml .Values.ingress.loadBalancerSourceRanges | indent 4 }}
   {{- end }}
   selector:
     app.kubernetes.io/name: ingress-nginx


### PR DESCRIPTION
Kinda janky, but this is never to be merged. We'll use this commit for the release so these notices don't appear without proper doucmentation.