### PR TITLE
feat: remove deprecated v1beta APIs

### DIFF
--- a/kube-linter.yaml
+++ b/kube-linter.yaml
@@ -13,6 +13,7 @@ checks:
     - host-pid
     - mismatching-selector
     - no-anti-affinity
+    - no-extensions-v1beta
     - no-liveness-probe
     - no-read-only-root-fs
     - no-readiness-probe
@@ -27,7 +28,6 @@ checks:
     - unsafe-sysctls
     - writable-host-mount
   exclude:
-    - no-extensions-v1beta
     - required-annotation-email
     - required-label-owner
     - unset-cpu-requirements

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -59,7 +59,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole-{{ .Release.Namespace }}
@@ -125,7 +125,7 @@ rules:
       - list
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: nginx-ingress-role
@@ -169,7 +169,7 @@ rules:
     verbs:
       - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: nginx-ingress-role-nisa-binding
@@ -186,7 +186,7 @@ subjects:
     name: nginx-ingress-serviceaccount
     namespace: {{ .Release.Namespace | quote }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   # The cluster role binding needs to be namespaced to avoid
@@ -347,7 +347,7 @@ spec:
 {{- end }}
 {{- if or .Values.ingress.useDefault .Values.ingress.enable }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web-ingress
@@ -372,9 +372,11 @@ metadata:
   {{- end }}
 spec:
 {{- include "coder.ingress.tls" . }}
-  backend:
-    serviceName: {{ include "coder.serviceName" . }}
-    servicePort: 8080
+  defaultBackend:
+    service:
+      name: {{ include "coder.serviceName" . }}
+      port:
+        number: 8080
   {{- if not .Values.coderd.replica.enable }}
   rules:
   - host: {{ .Values.ingress.host | quote }}
@@ -382,76 +384,114 @@ spec:
       paths:
     {{- if or (not .Values.ingress.usePathWildcards) .Values.ingress.useDefault }}
       {{- if hasKey .Values "envproxy" }}
-      - path: /proxy/
+      - path: /proxy
+        pathType: Prefix
         backend:
-          serviceName: envproxy
-          servicePort: 8080
+          service:
+            name: envproxy
+            port:
+              number: 8080
       {{- end }}
-      - path: /api/
+      - path: /api
+        pathType: Prefix
         backend:
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
-      - path: /auth/
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
+      - path: /auth
+        pathType: Prefix
         backend:
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
       - path: /
+        pathType: Prefix
         backend:
           {{- if hasKey .Values "dashboard" }}
-          serviceName: dashboard
-          servicePort: 3000
+          service:
+            name: dashboard
+            port:
+              number: 3000
           {{- else }}
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
           {{- end }}
     {{- if ne .Values.devurls.host "" }}
   - host: {{ .Values.devurls.host | quote }}
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
           {{- if hasKey .Values "envproxy" }}
-          serviceName: envproxy
-          servicePort: 8080
+          service:
+            name: envproxy
+            port:
+              number: 8080
           {{- else }}
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
           {{- end }}
     {{- end }}
     {{- else }}
-      - path: /proxy/*
+      - path: /proxy
+        pathType: Prefix
         backend:
-          serviceName: envproxy
-          servicePort: 8080
-      - path: /api/*
+          service:
+            name: envproxy
+            port:
+              number: 8080
+      - path: /api
+        pathType: Prefix
         backend:
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
-      - path: /auth/*
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
+      - path: /auth
+        pathType: Prefix
         backend:
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
-      - path: /*
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
+      - path: /
+        pathType: Prefix
         backend:
           {{- if hasKey .Values "dashboard" }}
-          serviceName: dashboard
-          servicePort: 3000
+          service:
+            name: dashboard
+            port:
+              number: 3000
           {{- else }}
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
           {{- end }}
     {{- if ne .Values.devurls.host "" }}
   - host: {{ .Values.devurls.host | quote }}
     http:
       paths:
-      - path: /*
+      - path: /
+        pathType: Prefix
         backend:
           {{- if hasKey .Values "envproxy" }}
-          serviceName: envproxy
-          servicePort: 8080
+          service:
+            name: envproxy
+            port:
+              number: 8080
           {{- else }}
-          serviceName: {{ include "coder.serviceName" . }}
-          servicePort: 8080
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 8080
           {{- end }}
     {{- end }}
     {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -382,7 +382,7 @@ spec:
   - host: {{ .Values.ingress.host | quote }}
     http:
       paths:
-    {{- if or (not .Values.ingress.usePathWildcards) .Values.ingress.useDefault }}
+    {{- if .Values.ingress.useDefault }}
       {{- if hasKey .Values "envproxy" }}
       - path: /proxy
         pathType: Prefix
@@ -420,7 +420,7 @@ spec:
             port:
               number: 8080
           {{- end }}
-    {{- if ne .Values.devurls.host "" }}
+      {{- if ne .Values.devurls.host "" }}
   - host: {{ .Values.devurls.host | quote }}
     http:
       paths:
@@ -438,62 +438,7 @@ spec:
             port:
               number: 8080
           {{- end }}
-    {{- end }}
-    {{- else }}
-      - path: /proxy
-        pathType: Prefix
-        backend:
-          service:
-            name: envproxy
-            port:
-              number: 8080
-      - path: /api
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "coder.serviceName" . }}
-            port:
-              number: 8080
-      - path: /auth
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "coder.serviceName" . }}
-            port:
-              number: 8080
-      - path: /
-        pathType: Prefix
-        backend:
-          {{- if hasKey .Values "dashboard" }}
-          service:
-            name: dashboard
-            port:
-              number: 3000
-          {{- else }}
-          service:
-            name: {{ include "coder.serviceName" . }}
-            port:
-              number: 8080
-          {{- end }}
-    {{- if ne .Values.devurls.host "" }}
-  - host: {{ .Values.devurls.host | quote }}
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          {{- if hasKey .Values "envproxy" }}
-          service:
-            name: envproxy
-            port:
-              number: 8080
-          {{- else }}
-          service:
-            name: {{ include "coder.serviceName" . }}
-            port:
-              number: 8080
-          {{- end }}
-    {{- end }}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -31,11 +31,6 @@ ingress:
   # would like to bring your own ingress and hook Coder into that instead, set
   # this value to false.
   useDefault: true
-  # ingress.usePathWildcards -- Whether or not the ingress object should use
-  # path wildcards, i.e., ending with "/*". Some ingresses require this
-  # while others do not. You should check which path style your ingress
-  # requires. For ingress-nginx this should be set to false.
-  usePathWildcards: false
   # ingress.host -- The hostname to use for accessing the platform. This can
   # be left blank, and the user can still access the platform from the external
   # IP or a DNS name that resolves to the external IP address.


### PR DESCRIPTION
Replace the use of deprecated apiVersions with the corresponding
stable versions.

--

Tested this manually in the latest monorepo.