### PR TITLE
feat: remove runAsUser and add runAsNonRoot

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -40,11 +40,8 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
-      # coder:coder
       securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        runAsNonRoot: true
       restartPolicy: Always
       # terminationGracePeriodSeconds should be set to the upper bound for container rebuilds and creates.
       # 5 minutes
@@ -94,6 +91,9 @@ spec:
               /wait_postgres.sh --host="$DB_HOST" --port="$DB_PORT" -U "$DB_USER";
               echo Starting entrypoint.sh;
               exec /entrypoint.sh coderd migrate up
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
       {{- end }}
       containers:
         - name: {{ include "coder.serviceName" . }}

--- a/templates/dashboard.yaml
+++ b/templates/dashboard.yaml
@@ -31,13 +31,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
-      # coder:coder
-      securityContext:
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       restartPolicy: Always
       serviceAccountName: dashboard
+      securityContext:
+        runAsNonRoot: true
 {{- include "coder.services.nodeSelector" . | indent 6 }}
 {{- include "coder.serviceTolerations" . | indent 6 }}
       containers:

--- a/templates/envproxy.yaml
+++ b/templates/envproxy.yaml
@@ -46,12 +46,8 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
-      # coder:coder
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
       restartPolicy: Always
       # 4 hours
       terminationGracePeriodSeconds: {{ .Values.envproxy.terminationGracePeriodSeconds }}


### PR DESCRIPTION
Remove the runAsUser setting so that we run as the default image
USER (coder, uid 1000) in unrestricted Kubernetes environments.
In restricted security environments, such as OpenShift with the
restricted Security Context Constraint, we will run as the uid
for the namespace.

This also applies additional security constraints, preventing
privilege escalation for the migration container and running
as a non-root user.

---

I tested this in GKE and OpenShift with the default `restricted` SCC:

```
22:33 coder@jawnsy-m ~/projects/enterprise-helm $ kubectl exec -it dashboard-85bdd59bd5-b7cpz -- id
uid=1000630000(1000630000) gid=0(root) groups=0(root),1000630000
```