### PR TITLE
fix: Migrations prefer old value over new

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,9 +6,8 @@
   {{- $found := true }}
   {{- range $_, $keypart := splitList "." $key }}
     {{- if $found }}
-      {{- if index $values $keypart  }}
-        {{- $values = index $values $keypart }}
-      {{- else }}
+      {{- $values = index $values $keypart }}
+      {{- if kindIs "invalid" $values  }}
         {{- $found = false }}
       {{- end }}
     {{- end }}

--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -84,9 +84,9 @@ volumeMounts:
   coder-managed services.
 */}}
 {{- define "coder.serviceTolerations" }}
-{{- if .Values.serviceTolerations }}
+{{- if ne (include "movedValue" (dict "Values" .Values "Key" "services.tolerations")) "" }}
 tolerations:
-{{ toYaml .Values.serviceTolerations }}
+{{ include "movedValue" (dict "Values" .Values "Key" "services.tolerations") }}
 {{- end }}
 {{- end }}
 {{/*


### PR DESCRIPTION
If an old value is specified, migrations will now prefer that.

This bug was found with the deprecated value `postgres.useDefault=false`... since the new one was technically set with `postgres.default.enable=true`, it skipped the fallback.