### PR TITLE
feat: configurable pod and container security contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,26 @@ View [our docs](https://coder.com/docs/setup/installation) for detailed installa
 
 | Key                 | Type | Description | Default                         |
 | ------------------- | ---- | ----------- | ------------------------------- |
-| coderd | object | Primary service responsible for all things Coder! | `{"builtinProviderServiceAccount":{"annotations":{},"labels":{}},"devurlsHost":"","image":"","replicas":1,"resources":{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"satellite":{"accessURL":"","enable":false,"primaryURL":""},"securityContext":{"readOnlyRootFilesystem":true},"serviceSpec":{"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerSourceRanges":[],"type":"LoadBalancer"},"tls":{"devurlsHostSecretName":"","hostSecretName":""}}` |
+| coderd | object | Primary service responsible for all things Coder! | `{"builtinProviderServiceAccount":{"annotations":{},"labels":{}},"devurlsHost":"","image":"","podSecurityContext":{"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}},"replicas":1,"resources":{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}},"satellite":{"accessURL":"","enable":false,"primaryURL":""},"securityContext":{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}},"serviceSpec":{"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerSourceRanges":[],"type":"LoadBalancer"},"tls":{"devurlsHostSecretName":"","hostSecretName":""}}` |
 | coderd.builtinProviderServiceAccount | object | Customize the built-in Kubernetes provider service account. | `{"annotations":{},"labels":{}}` |
 | coderd.builtinProviderServiceAccount.annotations | object | A KV mapping of annotations. See: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ | `{}` |
 | coderd.builtinProviderServiceAccount.labels | object | Add labels to the service account used for the built-in provider. | `{}` |
 | coderd.devurlsHost | string | Wildcard hostname to allow matching against custom-created dev URLs. Leaving as an empty string results in DevURLs being disabled. | `""` |
 | coderd.image | string | Injected by Coder during release. | `""` |
+| coderd.podSecurityContext | object | Fields related to the pod's security context (as opposed to the container). Some fields are also present in the container security context, which will take precedence over these values. | `{"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` |
+| coderd.podSecurityContext.runAsNonRoot | bool | Requires that containers in the pod run as a non-privileged user. | `true` |
+| coderd.podSecurityContext.runAsUser | int | Sets the user id of the pod. This must not be set to root (uid 0). | `1000` |
+| coderd.podSecurityContext.seccompProfile | object | Sets the seccomp profile for the pod. If set, the container security context setting will take precedence over this value. | `{"type":"RuntimeDefault"}` |
 | coderd.replicas | int | The number of Kubernetes Pod replicas. | `1` |
 | coderd.resources | object | Kubernetes resource specification for coderd pods. To unset a value, set it to "". To unset all values, set resources to nil. | `{"limits":{"cpu":"250m","memory":"512Mi"},"requests":{"cpu":"250m","memory":"512Mi"}}` |
 | coderd.satellite | object | Deploy a satellite to geodistribute access to workspaces for lower latency. | `{"accessURL":"","enable":false,"primaryURL":""}` |
 | coderd.satellite.accessURL | string | URL of the satellite that clients will connect to. e.g. https://sydney.coder.myorg.com | `""` |
 | coderd.satellite.enable | bool | Run coderd as a satellite pointing to a primary deployment. Satellite enable low-latency access to workspaces all over the world. Read more: TODO: Link to docs. | `false` |
 | coderd.satellite.primaryURL | string | URL of the primary Coder deployment. Must be accessible from the satellite and clients. eg. https://coder.myorg.com | `""` |
-| coderd.securityContext | object | Fields related to the container's security context (as opposed to the pod). | `{"readOnlyRootFilesystem":true}` |
+| coderd.securityContext | object | Fields related to the container's security context (as opposed to the pod). Some fields are also present in the pod security context, in which case these values will take precedence. | `{"allowPrivilegeEscalation":false,"readOnlyRootFilesystem":true,"seccompProfile":{"type":"RuntimeDefault"}}` |
+| coderd.securityContext.allowPrivilegeEscalation | bool | Controls whether the container can gain additional privileges, such as escalating to root. It is recommended to leave this setting disabled in production. | `false` |
+| coderd.securityContext.readOnlyRootFilesystem | bool | Mounts the container's root filesystem as read-only. It is recommended to leave this setting enabled in production. This will override the same setting in the pod | `true` |
+| coderd.securityContext.seccompProfile | object | Sets the seccomp profile for the migration and runtime containers. | `{"type":"RuntimeDefault"}` |
 | coderd.serviceSpec | object | Specification to inject for the coderd service. See: https://kubernetes.io/docs/concepts/services-networking/service/ | `{"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerSourceRanges":[],"type":"LoadBalancer"}` |
 | coderd.serviceSpec.externalTrafficPolicy | string | Set the traffic policy for the service. See: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip | `"Local"` |
 | coderd.serviceSpec.loadBalancerIP | string | Set the external IP address of the Ingress service. | `""` |

--- a/examples/openshift/openshift.values.yaml
+++ b/examples/openshift/openshift.values.yaml
@@ -2,22 +2,14 @@ coderd:
   serviceSpec:
     type: ClusterIP
   replicas: 1
-  resources:
-    requests:
-      cpu: "0m"
-      memory: "32Mi"
   turn:
     enable: true
   podSecurityContext:
-    seccompProfile:
-      type: RuntimeDefault
+    runAsUser: null
+    seccompProfile: null
   securityContext:
-    seccompProfile:
-      type: RuntimeDefault
     readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsUser: 1000
-    runAsGroup: 1000
+    seccompProfile: null
 
 postgres:
   default:

--- a/kube-linter.yaml
+++ b/kube-linter.yaml
@@ -1,4 +1,5 @@
 checks:
+  doNotAutoAddDefaults: true
   include:
     - cluster-admin-role-binding
     - dangling-service

--- a/scripts/test_helm.sh
+++ b/scripts/test_helm.sh
@@ -15,15 +15,16 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 
 EXAMPLES=(
   kind
+  openshift
 )
 
 BUILD="$PROJECT_ROOT/build"
 mkdir -p "$BUILD"
 
 for example in "${EXAMPLES[@]}"; do
-  run_trace false helm template "$PROJECT_ROOT" \
+  run_trace false helm template "$example" "$PROJECT_ROOT" \
+    --create-namespace \
     --release-name \
-    --name-template="$example" \
     --values="$PROJECT_ROOT/examples/images.yaml" \
     --values="$PROJECT_ROOT/examples/$example/$example.values.yaml" \
     --output-dir="$BUILD" \| indent

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -29,7 +29,11 @@ spec:
       {{- end }}
     spec:
       securityContext:
-        runAsNonRoot: true
+        {{- if hasKey .Values "cemanager" }}
+        {{- toYaml .Values.cemanager.podSecurityContext | nindent 8 }}
+        {{- else }}
+        {{- toYaml .Values.coderd.podSecurityContext | nindent 8 }}
+        {{- end }}
       restartPolicy: Always
       # terminationGracePeriodSeconds should be set to the upper bound for container rebuilds and creates.
       # 5 minutes
@@ -73,8 +77,11 @@ spec:
             - migrate
             - up
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            {{- if hasKey .Values "cemanager" }}
+            {{- toYaml .Values.cemanager.securityContext | nindent 12 }}
+            {{- else }}
+            {{- toYaml .Values.coderd.securityContext | nindent 12 }}
+            {{- end }}
       {{- end }}
       containers:
         - name: {{ include "coder.serviceName" . }}
@@ -88,11 +95,10 @@ spec:
             - name: tcp-t-{{ include "coder.serviceName" . }}
               containerPort: 5349
           securityContext:
-            allowPrivilegeEscalation: false
             {{- if hasKey .Values "cemanager" }}
-            readOnlyRootFilesystem: {{ merge .Values dict | dig "cemanager" "securityContext" "readOnlyRootFilesystem" true }}
+            {{- toYaml .Values.cemanager.securityContext | nindent 12 }}
             {{- else }}
-            readOnlyRootFilesystem: {{ merge .Values dict | dig "coderd" "securityContext" "readOnlyRootFilesystem" true }}
+            {{- toYaml .Values.coderd.securityContext | nindent 12 }}
             {{- end }}
           # coderd is a daemon service, no need to allocate a tty for it.
           tty: false

--- a/values.yaml
+++ b/values.yaml
@@ -50,13 +50,39 @@ coderd:
     # eg. https://coder.myorg.com
     primaryURL: ""
 
+  # coderd.podSecurityContext -- Fields related to the pod's security context
+  # (as opposed to the container). Some fields are also present in the
+  # container security context, which will take precedence over these values.
+  podSecurityContext:
+    # coderd.podSecurityContext.runAsNonRoot -- Requires that containers in
+    # the pod run as a non-privileged user.
+    runAsNonRoot: true
+    # coderd.podSecurityContext.runAsUser -- Sets the user id of the pod.
+    # This must not be set to root (uid 0).
+    runAsUser: 1000
+    # coderd.podSecurityContext.seccompProfile -- Sets the seccomp profile
+    # for the pod. If set, the container security context setting will take
+    # precedence over this value.
+    seccompProfile:
+      type: RuntimeDefault
+
   # coderd.securityContext -- Fields related to the container's security
-  # context (as opposed to the pod).
+  # context (as opposed to the pod). Some fields are also present in the pod
+  # security context, in which case these values will take precedence.
   securityContext:
-    # coderd.securityContext.readonlyRootFilesystem -- Sets the root filesystem
-    # of the container to read-only. It is recommended to leave this setting enabled
-    # in production.
+    # coderd.securityContext.readOnlyRootFilesystem -- Mounts the container's
+    # root filesystem as read-only. It is recommended to leave this setting
+    # enabled in production. This will override the same setting in the pod
     readOnlyRootFilesystem: true
+    # coderd.securityContext.seccompProfile -- Sets the seccomp profile for
+    # the migration and runtime containers.
+    seccompProfile:
+      type: RuntimeDefault
+    # coderd.securityContext.allowPrivilegeEscalation -- Controls whether
+    # the container can gain additional privileges, such as escalating to
+    # root. It is recommended to leave this setting disabled in production.
+    allowPrivilegeEscalation: false
+
   # coderd.resources -- Kubernetes resource specification for coderd pods.
   # To unset a value, set it to "". To unset all values, set resources to nil.
   resources:
@@ -66,6 +92,7 @@ coderd:
     limits:
       cpu: "250m"
       memory: "512Mi"
+
   # coderd.builtinProviderServiceAccount -- Customize the built-in Kubernetes
   # provider service account.
   builtinProviderServiceAccount:
@@ -75,6 +102,7 @@ coderd:
     # coderd.builtinProviderServiceAccount.labels -- Add labels to the service account
     # used for the built-in provider.
     labels: {}
+
 # envbox -- Required for running Docker inside containers. See requirements:
 # https://coder.com/docs/coder/v1.19/admin/workspace-management/cvms
 envbox:


### PR DESCRIPTION
I tested this in dev-3, seems to work fine. I haven't touched the other containers, since we're phasing them out anyways.

More info about seccomp: https://kubernetes.io/docs/tutorials/clusters/seccomp/

The default option isn't very restrictive, but is better than nothing and suitable for most applications.