### PR TITLE
feat: wait for postgres availability in Go

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -67,14 +67,11 @@ spec:
               value: "true"
 {{- include "coder.postgres.env" . | indent 12 }}
           command:
-            # Bash is needed to pass signals correctly.
-            - /bin/bash
-            - -c
-            - |
-              echo Waiting on db;
-              /wait_postgres.sh --host="$DB_HOST" --port="$DB_PORT" -U "$DB_USER";
-              echo Starting entrypoint.sh;
-              exec /entrypoint.sh coderd migrate up
+            - /entrypoint.sh
+          args:
+            - coderd
+            - migrate
+            - up
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -155,21 +152,14 @@ spec:
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}
           command:
-            # Bash is needed to pass signals correctly.
-            - /bin/bash
-            - -c
-            - |
-              {{- if not .Values.coderd.replica.enable }}
-              echo Waiting on db;
-              PGSSLMODE="${DB_SSL_MODE:-prefer}" /wait_postgres.sh --host="$DB_HOST" --port="$DB_PORT" -U "$DB_USER";
-              echo Starting entrypoint.sh;
-              # Pass signals down to the envmanager.
-              exec /entrypoint.sh coderd run
-              {{- else }}
-              echo Starting replica;
-              # Pass signals down to the envmanager.
-              exec /entrypoint.sh coderd replica
-              {{- end }}
+            - /entrypoint.sh
+          args:
+            - coderd
+            {{- if not .Values.coderd.replica.enable }}
+            - run
+            {{- else }}
+            - replica
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /cem-healthz


### PR DESCRIPTION
This change results in coderd waiting for PostgreSQL to become
available, rather than using pg_isready to do the same. This will
allow us to remove postgresql from the coderd container.

---

I tested this by scaling down the timescale statefulset and coderd deployment, scaling up coderd, waiting the logs for the migrations container, and starting up the timescale pod -- as expected, the coderd command re-connects to the database every 3 seconds until it succeeds:

```
2021-07-12 16:12:45.986 [ERROR] (migrate)       <global_flags.go:115>   open database   {"pqurl": "postgresql://coder@timescale.coder-jawnsy-m.svc.cluster.local:5432/coder?sslmode=disable\u0026timezone=UTC"} ...
  "error": connect to postgres:
               coder.com/m/product/coder/pkg/database.Open
                   /go/src/coder.com/m/product/coder/pkg/database/db.go:143
             - dial tcp 10.80.8.61:5432: connect: connection refused
2021-07-12 16:12:50.014 [ERROR] (migrate)       <global_flags.go:115>   open database   {"pqurl": "postgresql://coder@timescale.coder-jawnsy-m.svc.cluster.local:5432/coder?sslmode=disable\u0026timezone=UTC"} ...
  "error": connect to postgres:
               coder.com/m/product/coder/pkg/database.Open
                   /go/src/coder.com/m/product/coder/pkg/database/db.go:143
             - dial tcp 10.80.8.61:5432: connect: connection refused
2021-07-12 16:12:54.046 [ERROR] (migrate)       <global_flags.go:115>   open database   {"pqurl": "postgresql://coder@timescale.coder-jawnsy-m.svc.cluster.local:5432/coder?sslmode=disable\u0026timezone=UTC"} ...
  "error": connect to postgres:
               coder.com/m/product/coder/pkg/database.Open
                   /go/src/coder.com/m/product/coder/pkg/database/db.go:143
             - dial tcp 10.80.8.61:5432: connect: connection refused
2021-07-12 16:12:57.125 [INFO]  (migrate)       <migrate.go:71> running all unapplied migrations
2021-07-12 16:12:57.373 [INFO]  (migrate)       <migrations.go:298>     up migrations done      {"ran": 0, "took": "294.727µs"}
2021-07-12 16:12:57.383 [INFO]  (migrate)       <migrate.go:82> successfully migrated
```