### PR TITLE
fix: Add DevURL TLS secret to SSL_SERVER_*

### DIFF
--- a/templates/_common.tpl
+++ b/templates/_common.tpl
@@ -59,6 +59,11 @@ volumes:
     secret:
       secretName: {{ include "movedValue" (dict "Values" .Values "Key" "coderd.tls.hostSecretName") }}
 {{- end }}
+{{- if ne (include "movedValue" (dict "Values" .Values "Key" "coderd.tls.hostSecretName")) "" }}
+  - name: devurltls
+    secret:
+      secretName: {{ include "movedValue" (dict "Values" .Values "Key" "coderd.tls.devurlsHostSecretName") }}
+{{- end }}
 {{- end }}
 
 {{/* 
@@ -76,6 +81,11 @@ volumeMounts:
 {{- if ne (include "movedValue" (dict "Values" .Values "Key" "coderd.tls.hostSecretName")) "" }}
   - name: tls
     mountPath: /etc/ssl/certs/host
+    readOnly: true
+{{- end }}
+{{- if ne (include "movedValue" (dict "Values" .Values "Key" "coderd.tls.devurlsHostSecretName")) "" }}
+  - name: devurltls
+    mountPath: /etc/ssl/certs/devurls
     readOnly: true
 {{- end }}
 {{- end }}

--- a/templates/_migrate.tpl
+++ b/templates/_migrate.tpl
@@ -13,6 +13,7 @@
 {{- $_ := set $moved "coderd.serviceSpec.loadBalancerSourceRanges" "ingress.loadBalancerSourceRanges" }}
 {{- $_ := set $moved "coderd.serviceSpec.externalTrafficPolicy" "ingress.service.externalTrafficPolicy" }}
 {{- $_ := set $moved "coderd.tls.hostSecretName" "ingress.tls.hostSecretName" }}
+{{- $_ := set $moved "coderd.tls.devurlsHostSecretName" "ingress.tls.devurlsHostSecretName" }}
 {{- $_ := set $moved "postgres.default.storageClassName" "storageClassName" }}
 {{- $_ := set $moved "postgres.default.image" "timescale.image" }}
 {{- $_ := set $moved "postgres.default.resources" "timescale.resources" }}

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -144,11 +144,23 @@ spec:
             - name: CODER_REPLICA_ACCESS_URL
               value: {{ .Values.coderd.replica.accessURL | quote }}
             {{- end }}
+            {{- $serverCerts := list }}
+            {{- $serverKeys := list }}
             {{- if ne (include "movedValue" (dict "Values" .Values "Key" "coderd.tls.hostSecretName")) "" }}
+              {{ $serverCerts = append $serverCerts "/etc/ssl/certs/host/tls.crt" }}
+              {{ $serverKeys = append $serverKeys "/etc/ssl/certs/host/tls.key" }}
+            {{- end }}
+            {{- if ne (include "movedValue" (dict "Values" .Values "Key" "coderd.tls.devurlsHostSecretName")) "" }}
+              {{- $serverCerts = append $serverCerts "/etc/ssl/certs/devurls/tls.crt" }}
+              {{- $serverKeys = append $serverKeys "/etc/ssl/certs/devurls/tls.key" }}
+            {{- end }}
+            {{- if gt (len $serverCerts) 0 }}
             - name: SSL_SERVER_CERT_FILE
-              value: /etc/ssl/certs/host/tls.crt
+              value: {{ join ":" $serverCerts }}
+            {{- end }}
+            {{- if gt (len $serverKeys) 0 }}
             - name: SSL_SERVER_KEY_FILE
-              value: /etc/ssl/certs/host/tls.key
+              value: {{ join ":" $serverKeys }}
             {{- end }}
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}


### PR DESCRIPTION
This was omitted when transitioning to the simplified coderd Helm to begin testing as soon as possible.

coderd supports splitting by `:` to load certificates from path.