### PR TITLE
chore: add minimum Kubernetes version requirement

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,6 +6,13 @@ name: coder
 description: Coder moves developer workspaces to your cloud and centralizes their creation and management.
 appVersion: master
 version: 1.19.0
+# Coder follows the Kubernetes upstream version support policy, and the
+# latest stable release version of Coder supports the previous two minor
+# releases as well as the current release of Kubernetes at time of
+# publication.
+#
+# See: https://coder.com/docs/coder/latest/setup/kubernetes#supported-kubernetes-versions
+kubeVersion: ">= 1.19.0"
 home: https://coder.com
 keywords:
   - coder


### PR DESCRIPTION
Enforce the minimum Kubernetes version in Helm chart, according
to our version support policy.

--

When using an older version of Kubernetes, the error will look like this:

```shell-session
$ helm template --kube-version=1.18.1 coder .
Error: chart requires kubeVersion: >= 1.19.0 which is incompatible with Kubernetes v1.18.1
```

Also verified with `kind`:

```shell-session
$ kubectl get node
NAME                  STATUS   ROLES    AGE   VERSION
coder-control-plane   Ready    master   52s   v1.18.2
$ helm install coder . --namespace=coder
Error: chart requires kubeVersion: >= 1.19.0 which is incompatible with Kubernetes v1.18.2
```