### PR TITLE
Add tolerations and nodeSelector env vars to init container

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -70,6 +70,7 @@ spec:
             - name: VERBOSE
               value: "true"
 {{- include "coder.postgres.env" . | indent 12 }}
+{{- include "coder.environments.configMapEnv" . | indent 12 }}
           command:
             - /entrypoint.sh
           args:


### PR DESCRIPTION
This caused the migration to always have empty data