### PR TITLE
Separate ingress.usedefault from .enable

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -335,6 +335,8 @@ spec:
       protocol: TCP
 {{- end }}
 ---
+{{- end }}
+{{- if (merge .Values dict | dig "ingress" "enable" true) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:


### PR DESCRIPTION
This change allows ingress.enabled to create the ingress object for
use with another ingress controller. 
used in conjunction with coderd.serviceSpec.type=ClusterIP,
coderd.devurlsHost, and ingress.host to get the full ingress experience