### PR TITLE
chore: add minimum Kubernetes version requirement

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,6 +6,13 @@ name: coder
 description: Coder moves developer workspaces to your cloud and centralizes their creation and management.
 appVersion: master
 version: 1.19.0
+# Coder follows the Kubernetes upstream version support policy, and the
+# latest stable release version of Coder supports the previous two minor
+# releases as well as the current release of Kubernetes at time of
+# publication.
+#
+# See: https://coder.com/docs/coder/latest/setup/kubernetes#supported-kubernetes-versions
+kubeVersion: ">= 1.19.0-0"
 home: https://coder.com
 keywords:
   - coder


### PR DESCRIPTION
Enforce the minimum Kubernetes version in Helm chart, according
to our version support policy.

---

Trying this again... The problem/solution is documented here: https://github.com/helm/helm/issues/3810

```shell-session
$ helm template --kube-version=1.18.0 coder . >/dev/null
Error: chart requires kubeVersion: >= 1.19.0-0 which is incompatible with Kubernetes v1.18.0

Use --debug flag to render out invalid YAML
$ helm template --kube-version=1.19.1 coder . >/dev/null
$ helm template --kube-version=1.18.0 coder . >/dev/null
Error: chart requires kubeVersion: >= 1.19.0-0 which is incompatible with Kubernetes v1.18.0

Use --debug flag to render out invalid YAML
$ helm template --kube-version=1.19.10-gke.1600 coder . >/dev/null
$ helm template --kube-version=1.18.0-gke.1600 coder . >/dev/null
Error: chart requires kubeVersion: >= 1.19.0-0 which is incompatible with Kubernetes v1.18.0-gke.1600

Use --debug flag to render out invalid YAML
```

I didn't check a real install, but I did verify that this works on both OpenShift and GKE (dev-3) -- it says the image name is invalid because I'm installing from enterprise-helm, which doesn't have the image names injected:

```shell-session
$ kubectl cluster-info
Kubernetes control plane is running at https://api.openshift.cdr.dev:6443

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.3", GitCommit:"ca643a4d1f7bfe34773c74f79527be4afd95bf39", GitTreeState:"clean", BuildDate:"2021-07-15T21:04:39Z", GoVersion:"go1.16.6", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.0-1085+01c9f3f43ffcf0-dirty", GitCommit:"01c9f3f43ffcf096c29d51f3b6f2b6914b2b56a6", GitTreeState:"dirty", BuildDate:"2021-07-02T12:28:26Z", GoVersion:"go1.15.7", Compiler:"gc", Platform:"linux/amd64"}
$ helm upgrade --namespace=coder-jawnsy-m coder .
Error: UPGRADE FAILED: cannot patch "coderd" with kind Deployment: Deployment.apps "coderd" is invalid: [spec.template.spec.containers[0].image: Required value, spec.template.spec.initContainers[0].image: Required value]
$ gcloud container clusters get-credentials dev-3
Fetching cluster endpoint and auth data.
kubeconfig entry generated for dev-3.
$ kubectl cluster-info
Kubernetes control plane is running at https://34.67.189.3
GLBCDefaultBackend is running at https://34.67.189.3/api/v1/namespaces/kube-system/services/default-http-backend:http/proxy
KubeDNS is running at https://34.67.189.3/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
Metrics-server is running at https://34.67.189.3/api/v1/namespaces/kube-system/services/https:metrics-server:/proxy

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.3", GitCommit:"ca643a4d1f7bfe34773c74f79527be4afd95bf39", GitTreeState:"clean", BuildDate:"2021-07-15T21:04:39Z", GoVersion:"go1.16.6", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20+", GitVersion:"v1.20.8-gke.900", GitCommit:"28ab8501be88ea42e897ca8514d7cd0b436253d9", GitTreeState:"clean", BuildDate:"2021-06-30T09:23:36Z", GoVersion:"go1.15.13b5", Compiler:"gc", Platform:"linux/amd64"}
$ helm upgrade --namespace=coder-jawnsy-m coder .
Error: UPGRADE FAILED: cannot patch "coderd" with kind Deployment: Deployment.apps "coderd" is invalid: [spec.template.spec.containers[0].image: Required value, spec.template.spec.initContainers[0].image: Required value]
```

It gets past the version check, though, so I think this means everything is OK.