### PR TITLE
Load balancer TLS termination

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -247,19 +247,21 @@ spec:
   selector:
     coder.deployment: {{ include "coder.serviceName" . }}
   ports:
-    - name: tcp-{{ include "coder.serviceName" . }}
-      port: 80
-      targetPort: 8080
-      protocol: TCP
-      {{ if .Values.coderd.serviceNodePorts.http }}
-      nodePort: {{  .Values.coderd.serviceNodePorts.http  }}
-      {{ end }}
     - name: tcp-{{ include "coder.serviceName" . }}-https
       port: 443
+      {{- if .Values.coderd.httpsToHttp }}¬
       targetPort: 8443
       protocol: TCP
       {{ if .Values.coderd.serviceNodePorts.https }}
       nodePort: {{ .Values.coderd.serviceNodePorts.https }}
+      {{ end }}
+    - name: tcp-{{ include "coder.serviceName" . }}
+      port: 80
+      {{- end }}
+      targetPort: 8080
+      protocol: TCP
+      {{ if .Values.coderd.serviceNodePorts.http }}
+      nodePort: {{  .Values.coderd.serviceNodePorts.http  }}
       {{ end }}
 {{- else }}
 ---

--- a/values.yaml
+++ b/values.yaml
@@ -36,6 +36,11 @@ coderd:
   # coderd.serviceAnnotations -- Extra annotations to apply to the coderd service.
   serviceAnnotations: {}
 
+  # coderd.httpsToHttp -- eliminates the external http port and routes traffic from
+  # the external https port to the internal http port. Useful for when the load balancer
+  # performs TLS termination (like Amazon's ACM)
+  httpsToHttp: false
+
   # coderd.trustProxyIP -- Whether Coder should trust X-Real-IP and/or
   # X-Forwarded-For headers from your reverse proxy. This should only be turned
   # on if you're using a reverse proxy that sets both of these headers. This is


### PR DESCRIPTION
If TLS is terminated by an ALB, the service port 80 routes traffic without redirecting
to HTTPS and the HTTPS port presents an error since it's pointing to another HTTPS
port of the node.

This change allows the load balancer to expose only port 443 externally which routes to
the HTTP port of the coderd pod.