### PR TITLE
revert: "Load balancer TLS termination (#144)"

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -247,21 +247,19 @@ spec:
   selector:
     coder.deployment: {{ include "coder.serviceName" . }}
   ports:
-    - name: tcp-{{ include "coder.serviceName" . }}-https
-      port: 443
-      {{- if .Values.coderd.httpsToHttp }}¬
-      targetPort: 8443
-      protocol: TCP
-      {{ if .Values.coderd.serviceNodePorts.https }}
-      nodePort: {{ .Values.coderd.serviceNodePorts.https }}
-      {{ end }}
     - name: tcp-{{ include "coder.serviceName" . }}
       port: 80
-      {{- end }}
       targetPort: 8080
       protocol: TCP
       {{ if .Values.coderd.serviceNodePorts.http }}
       nodePort: {{  .Values.coderd.serviceNodePorts.http  }}
+      {{ end }}
+    - name: tcp-{{ include "coder.serviceName" . }}-https
+      port: 443
+      targetPort: 8443
+      protocol: TCP
+      {{ if .Values.coderd.serviceNodePorts.https }}
+      nodePort: {{ .Values.coderd.serviceNodePorts.https }}
       {{ end }}
 {{- else }}
 ---

--- a/values.yaml
+++ b/values.yaml
@@ -36,11 +36,6 @@ coderd:
   # coderd.serviceAnnotations -- Extra annotations to apply to the coderd service.
   serviceAnnotations: {}
 
-  # coderd.httpsToHttp -- eliminates the external http port and routes traffic from
-  # the external https port to the internal http port. Useful for when the load balancer
-  # performs TLS termination (like Amazon's ACM)
-  httpsToHttp: false
-
   # coderd.trustProxyIP -- Whether Coder should trust X-Real-IP and/or
   # X-Forwarded-For headers from your reverse proxy. This should only be turned
   # on if you're using a reverse proxy that sets both of these headers. This is


### PR DESCRIPTION
This reverts commit be5b7f6e8872517d24eda0fffdc1373a7e3bc78e.

--

Reverted this because it broke dogfood despite no changes being made to the example values files. This means that this change was not backward-compatible.