### PR TITLE
add example for custom ingress

### DIFF
--- a/examples/ingress/ingress.values.yaml
+++ b/examples/ingress/ingress.values.yaml
@@ -4,6 +4,7 @@
 # by creating a LoadBalancer service
 coderd:
   serviceNext: true
+  devurlsHost: '*.devurls.coderhost.com'
   serviceSpec:
     type: ClusterIP
     # The values.yaml file in the chart includes LoadBalancer
@@ -12,6 +13,12 @@ coderd:
     loadBalancerIP: null
     externalTrafficPolicy: null
     loadBalancerSourceRanges: null
-# Add your own ingress spec based on the type of ingress you
-# have deployed in your cluster. Send all traffic to the 
-# coderd service on ports 80, and 443.
+# Add the ingress values section to enable the ingress resource
+# without the controller
+ingress:
+  # Enable set to true creates the ingress resource
+  enable: true
+  # Ingress needs a host name so it can share a controller
+  host: 'coder.coderhost.com'
+  # useDefault set to false disables creation of the ingress controller
+  useDefault: false

--- a/examples/ingress/ingress.values.yaml
+++ b/examples/ingress/ingress.values.yaml
@@ -1,0 +1,17 @@
+# Using coder with ingress in versions from 1.21 and newer
+# Coder's built-in ingress controller is no longer packaged
+# the coderd pod does not require a fanout so it is exposed
+# by creating a LoadBalancer service
+coderd:
+  serviceNext: true
+  serviceSpec:
+    type: ClusterIP
+    # The values.yaml file in the chart includes LoadBalancer
+    # specs which need to have the keys removed using null
+    # this does not work as a sub-chart
+    loadBalancerIP: null
+    externalTrafficPolicy: null
+    loadBalancerSourceRanges: null
+# Add your own ingress spec based on the type of ingress you
+# have deployed in your cluster. Send all traffic to the 
+# coderd service on ports 80, and 443.

--- a/examples/ingress/ingress.values.yaml
+++ b/examples/ingress/ingress.values.yaml
@@ -22,3 +22,5 @@ ingress:
   host: 'coder.coderhost.com'
   # useDefault set to false disables creation of the ingress controller
   useDefault: false
+  # add annotations for TLS issuers and such
+  annotations: {}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -409,3 +409,32 @@ spec:
   {{- end }}
 {{- end }}
 ---
+{{- if and (merge .Values dict | dig "coderd" "serviceNext" true) (merge .Values dict | dig "ingress" "enable" true) }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coderd-ingress
+spec:
+{{- include "coder.ingress.tls" . }}
+  rules:
+  - host: {{ merge .Values dict | dig "ingress" "host" "" | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 80
+  - host: {{ merge .Values dict | dig "coderd" "devurlsHost" "" | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "coder.serviceName" . }}
+            port:
+              number: 80
+{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -414,6 +414,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: coderd-ingress
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  {{- range $key, $value := merge .Values dict | dig "ingress" "annotations" dict }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
 spec:
 {{- include "coder.ingress.tls" . }}
   rules:


### PR DESCRIPTION
I'm using the following command to ensure the right objects are being created: 

`helm template coder . -f examples/ingress/ingress.values.yaml --set postgres.default.enable=false`

The goal of this is to:

- [x] Suggest values for when deploying into a cluster that can't make more LBs
- [x] Add a simple ingress object that will exist when `ingress.enable=true`
- [x] Support TLS-at-the-ingress with annotations and such