### PR TITLE
feat: add network policy for workspaces

### DIFF
--- a/templates/networkpolicies.yaml
+++ b/templates/networkpolicies.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-deny-all
+  namespace: {{ .Release.Namespace }}
+spec:
+  # Deny all ingress traffic for workspace pods. The coder agent initiates
+  # all network traffic (TURN-over-HTTPS or STUN)
+  podSelector:
+    matchLabels:
+      com.coder.resource: "true"
+  policyTypes:
+    - Ingress
+  ingress: []


### PR DESCRIPTION
This will prevent ingress traffic for all workspace pods (already done by coderd on workspace start, but requires creation and cleanup of a network policy) via a policy defined in the Helm chart. In the future, this will make it possible to customize the ingress traffic if desired.

New policy:

```shell-session
$ kubectl describe networkpolicy ingress-deny-all
Name:         ingress-deny-all
Namespace:    coder-jawnsy-m
Created on:   2021-09-01 00:04:33 +0000 UTC
Labels:       app.kubernetes.io/managed-by=Helm
Annotations:  meta.helm.sh/release-name: coder
              meta.helm.sh/release-namespace: coder-jawnsy-m
Spec:
  PodSelector:     com.coder.resource=true
  Allowing ingress traffic:
    <none> (Selected pods are isolated for ingress connectivity)
  Not affecting egress traffic
  Policy Types: Ingress
```

Existing coderd-created policy (will still exist in 1.23, to be removed in 1.24 or later):

```
$ kubectl describe networkpolicy workspace-dxlmp
Name:         workspace-dxlmp
Namespace:    coder-jawnsy-m
Created on:   2021-09-01 00:07:39 +0000 UTC
Labels:       com.coder.environment.id=612d6e4a-21cb54ee1dc59d651f4e19e5
              com.coder.environment.name=workspace
              com.coder.resource=true
              com.coder.workspace.id=612d6e4a-21cb54ee1dc59d651f4e19e5
              com.coder.workspace.name=workspace
Annotations:  <none>
Spec:
  PodSelector:     com.coder.environment.id=612d6e4a-21cb54ee1dc59d651f4e19e5
  Allowing ingress traffic:
    <none> (Selected pods are isolated for ingress connectivity)
  Not affecting egress traffic
  Policy Types: Ingress
```

This is what [Cilium's Network Policy Editor](https://editor.cilium.io/) shows for this rule:

![image](https://user-images.githubusercontent.com/52710/131591725-998048e1-e120-4191-a57d-3849a7885832.png)
