### PR TITLE
Fix: port mismatch ingress to service

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -432,7 +432,7 @@ spec:
           service:
             name: {{ include "coder.serviceName" . }}
             port:
-              number: 80
+              number: 8080
   - host: {{ merge .Values dict | dig "coderd" "devurlsHost" "" | quote }}
     http:
       paths:
@@ -442,5 +442,5 @@ spec:
           service:
             name: {{ include "coder.serviceName" . }}
             port:
-              number: 80
+              number: 8080
 {{- end }}


### PR DESCRIPTION
Ingress port needs to match the port number on the coderd service.

@deansheather This one.