### PR TITLE
chore: lint all examples, including ingress

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -10,7 +10,7 @@ check_dependencies \
   git \
   helm
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
 BUILD="$PROJECT_ROOT/build"
 mkdir -p "$BUILD"

--- a/scripts/test_helm.sh
+++ b/scripts/test_helm.sh
@@ -15,7 +15,7 @@ check_dependencies \
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
 mapfile -t EXAMPLES < <(
-  find $PROJECT_ROOT/examples/ -mindepth 1 -type d -printf "%f\n"
+  find "$PROJECT_ROOT/examples/" -mindepth 1 -type d -printf "%f\n"
 )
 
 BUILD="$PROJECT_ROOT/build"

--- a/scripts/test_helm.sh
+++ b/scripts/test_helm.sh
@@ -9,17 +9,19 @@ source "./lib.sh"
 
 check_dependencies \
   git \
-  helm
+  helm \
+  kube-linter
 
-PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
 EXAMPLES=(
+  ingress
   kind
   openshift
 )
 
 BUILD="$PROJECT_ROOT/build"
-mkdir -p "$BUILD"
+mkdir --parents "$BUILD"
 
 for example in "${EXAMPLES[@]}"; do
   run_trace false helm template "$example" "$PROJECT_ROOT" \
@@ -28,7 +30,7 @@ for example in "${EXAMPLES[@]}"; do
     --release-name \
     --values="$PROJECT_ROOT/examples/images.yaml" \
     --values="$PROJECT_ROOT/examples/$example/$example.values.yaml" \
-    --output-dir="$BUILD" \| indent
+    --output-dir="$BUILD"
 done
 
 run_trace false kube-linter lint --config="$PROJECT_ROOT/kube-linter.yaml" "$BUILD"

--- a/scripts/test_helm.sh
+++ b/scripts/test_helm.sh
@@ -14,10 +14,8 @@ check_dependencies \
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel)
 
-EXAMPLES=(
-  ingress
-  kind
-  openshift
+mapfile -t EXAMPLES < <(
+  find $PROJECT_ROOT/examples/ -mindepth 1 -type d -printf "%f\n"
 )
 
 BUILD="$PROJECT_ROOT/build"


### PR DESCRIPTION
Lint all subdirectories under examples automatically. This has the
effect of linting the ingress example, in addition to the existing
kind and openshift examples.