### PR TITLE
feat: Strip devurl suffixs from input for host

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -433,7 +433,8 @@ spec:
             name: {{ include "coder.serviceName" . }}
             port:
               name: tcp-{{ include "coder.serviceName" . }}
-  - host: {{ merge .Values dict | dig "coderd" "devurlsHost" "" | quote }}
+          {{ $devURLHost := merge .Values dict | dig "coderd" "devurlsHost" "" }}
+  - host: {{ regexReplaceAll "\\*[^.]*(\\..*)" $devURLHost "*${1}" | quote }}
     http:
       paths:
       - path: /

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -434,7 +434,8 @@ spec:
             port:
               name: tcp-{{ include "coder.serviceName" . }}
           {{ $devURLHost := merge .Values dict | dig "coderd" "devurlsHost" "" }}
-          # Regex docs on '*-suffix.example.com'
+          # Regex docs on '*-suffix.example.com'. This is required as the original input including the suffix is
+          # not a legal ingress host. We need to remove the suffic, and keep the wildcard '*'.
           #   - '\\*'     Starts with '*'
           #   - '[^.]*'   Suffix is 0 or more characters, '-suffix'
           #   - '('       Start domain capture grp

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -434,6 +434,13 @@ spec:
             port:
               name: tcp-{{ include "coder.serviceName" . }}
           {{ $devURLHost := merge .Values dict | dig "coderd" "devurlsHost" "" }}
+          # Regex docs on '*-suffix.example.com'
+          #   - '\\*'     Starts with '*'
+          #   - '[^.]*'   Suffix is 0 or more characters, '-suffix'
+          #   - '('       Start domain capture grp
+          #   -   '\\.'     The domain should be separated with a '.' from the subdomain
+          #   -   '.*'      Rest of the domain.
+          #   - ')'       $1 is the ''.example.com'
   - host: {{ regexReplaceAll "\\*[^.]*(\\..*)" $devURLHost "*${1}" | quote }}
     http:
       paths:


### PR DESCRIPTION
Devurls will now support suffixs, this strips that suffix and places `*.domain`.

The `*.domain` will include the suffix for the DNS, but the Go code needs to read the suffix.

Example:
Input: `*-prod.example.com`
Output: `*.example.com`

## Question

Should I implement some sort of regex check to test the suffix is valid DNS characters and fail if they do something wonky? I'd like to add some basic validation, but don't want to break old deployments.