### PR TITLE
cleanup: Execute coderd directly

### DIFF
--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -81,8 +81,6 @@ spec:
 {{- include "coder.postgres.env" . | indent 12 }}
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
           command:
-            - /entrypoint.sh
-          args:
             - coderd
             - migrate
             - up
@@ -191,8 +189,6 @@ spec:
 {{- include "coder.environments.configMapEnv" . | indent 12 }}
 {{- include "coder.postgres.env" . | indent 12 }}
           command:
-            - /entrypoint.sh
-          args:
             - coderd
             {{- if not .Values.coderd.satellite.enable }}
             - run


### PR DESCRIPTION
The entrypoint script previously set environment variables as
flags to coderd. coderd now consumes the environment variables
directly, removing the need for the script.

There were a few variables that didn't match up, and I'll be creating
a PR to fix those.