### PR TITLE
chore: add update strategy configuration

### DIFF
--- a/kube-linter.yaml
+++ b/kube-linter.yaml
@@ -19,6 +19,7 @@ checks:
     - no-liveness-probe
     - no-read-only-root-fs
     - no-readiness-probe
+    - no-rolling-update-strategy
     - non-existent-service-account
     - privilege-escalation-container
     - privileged-container
@@ -39,8 +40,6 @@ checks:
     - access-to-secrets
     # TODO: evaluate high availability by default
     - minimum-three-replicas
-    # TODO: add update strategy
-    - no-rolling-update-strategy
     # TODO: add network policy for coderd and timescale pods
     - non-isolated-pod
     - required-annotation-email

--- a/templates/coderd.yaml
+++ b/templates/coderd.yaml
@@ -16,6 +16,7 @@ metadata:
 spec:
   replicas: {{ include "movedValue" (dict "Values" .Values "Key" "coderd.replicas" 1) }}
   strategy:
+    type: RollingUpdate
     rollingUpdate:
       maxSurge: "25%"
       maxUnavailable: "25%"

--- a/templates/timescale.yaml
+++ b/templates/timescale.yaml
@@ -30,6 +30,10 @@ metadata:
 spec:
   serviceName: timescale
   replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
   selector:
     matchLabels:
       app: timescale


### PR DESCRIPTION
Add the default update strategy settings, as these are checked
by the kube-linter linter. This is not a behavior change, and
simply encodes the default settings into our Chart.