### PR TITLE
fix: unset service externalTrafficPolicy in examples

### DIFF
--- a/examples/ingress/ingress.values.yaml
+++ b/examples/ingress/ingress.values.yaml
@@ -3,6 +3,7 @@ coderd:
   serviceSpec:
     # The Ingress will route traffic to the internal ClusterIP.
     type: ClusterIP
+    externalTrafficPolicy: ""
 
 ingress:
   enable: true

--- a/examples/kind/kind.values.yaml
+++ b/examples/kind/kind.values.yaml
@@ -3,6 +3,7 @@ coderd:
   serviceSpec:
     # Avoid provisioning a LoadBalancer
     type: ClusterIP
+    externalTrafficPolicy: ""
 
   # Reduce resource requirements for deployments using kind, which
   # we typically use for development and test purposes only.

--- a/examples/openshift/openshift.values.yaml
+++ b/examples/openshift/openshift.values.yaml
@@ -3,6 +3,7 @@ coderd:
 
   serviceSpec:
     type: ClusterIP
+    externalTrafficPolicy: ""
 
   # OpenShift's default "restricted" Security Context Constraint
   # requires that these be unset. OpenShift manages the runAsUser

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -8,6 +8,23 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// MustFindService finds a service in the given slice of objects with the
+// given name, or fails the test.
+func MustFindService(t testing.TB, objs []runtime.Object, name string) *corev1.Service {
+	names := []string{}
+	for _, obj := range objs {
+		if service, ok := obj.(*corev1.Service); ok {
+			if service.Name == name {
+				return service
+			}
+			names = append(names, service.Name)
+		}
+	}
+
+	t.Fatalf("failed to find service %q, found %v", name, names)
+	return nil
+}
+
 // MustFindDeployment finds a deployment in the given slice of objects with the
 // given name, or fails the test.
 func MustFindDeployment(t testing.TB, objs []runtime.Object, name string) *appsv1.Deployment {


### PR DESCRIPTION
When using ClusterIP services, such as for Ingress objects, the
LoadBalancer-specific externalTrafficPolicy setting must not be
set, so explicitly unset it for those examples.