### PR TITLE
chore: fix cancel workflow action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.1
-        if: github.event_type == 'pull_request'
+        if: github.event_name == 'pull_request'
 
       - name: Checkout source
         uses: actions/checkout@v2
@@ -77,7 +77,7 @@ jobs:
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.1
-        if: github.event_type == 'pull_request'
+        if: github.event_name == 'pull_request'
 
       - name: Checkout source
         uses: actions/checkout@v2

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.9.1
-        if: github.event_type == 'pull_request'
+        if: github.event_name == 'pull_request'
 
       - name: Checkout source
         uses: actions/checkout@v2


### PR DESCRIPTION
Due to a typo (github.event_type rather than github.event_name),
the cancel previous runs workflow action was not running.